### PR TITLE
Fixed: Set keyboard type for stock input field(#2cqz21c)

### DIFF
--- a/src/views/count.vue
+++ b/src/views/count.vue
@@ -36,7 +36,7 @@
         </div>
         <ion-item>
           <ion-label position="floating">{{ $t("Stock") }}</ion-label>
-          <ion-input inputmode="numeric" v-model="product.quantity"></ion-input>
+          <ion-input type="number" min="0" inputmode="numeric" v-model="product.quantity"></ion-input>
         </ion-item>
         <ion-item lines="none">
           <ion-note id="stockCount">{{ $t("Enter the count of stock on the shelf.") }}</ion-note>

--- a/src/views/count.vue
+++ b/src/views/count.vue
@@ -36,7 +36,7 @@
         </div>
         <ion-item>
           <ion-label position="floating">{{ $t("Stock") }}</ion-label>
-          <ion-input v-model="product.quantity"></ion-input>
+          <ion-input inputmode="numeric" v-model="product.quantity"></ion-input>
         </ion-item>
         <ion-item lines="none">
           <ion-note id="stockCount">{{ $t("Enter the count of stock on the shelf.") }}</ion-note>


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

Closes #

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
when the user selects the stock input field, the system keyboard should be a number pad

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


**IMPORTANT NOTICE** - Remember to update `CHANGELOG.md` with description of your change


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [ ] I read and followed [contribution rules](https://github.com/DivanteLtd/vsf-capybara/blob/master/CONTRIBUTING.md)
- [ ] I have changed the target to hacktoberfest branch