### PR TITLE
fixed: incorrect facility locations on product detail page(#85zrgfqdj)

### DIFF
--- a/src/components/ProductListItem.vue
+++ b/src/components/ProductListItem.vue
@@ -33,6 +33,7 @@ export default defineComponent({
   props: ["product"],
   methods: {
     async viewProduct () {
+      await this.store.dispatch("product/updateCurrentProduct", this.product.sku)
       this.router.push({ path: `/count/${this.product.sku}` })
     }
   },

--- a/src/views/count.vue
+++ b/src/views/count.vue
@@ -116,9 +116,6 @@
         location: ""
       }
     },
-    ionViewWillEnter() {
-      this.store.dispatch("product/updateCurrentProduct", this.$route.params.sku)
-    },
     async mounted(){
       await this.getFacilityLocations();
     },


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

Closes #127 

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
Previously we were fetching locations in mounted hook and setting current product in ionViewWillEnter hook. The locations were fetched before the curent product was set. This lead to incorrect data.

Solution: Updated the code to set current product before routing to product detail page.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


**IMPORTANT NOTICE** - Remember to update `CHANGELOG.md` with description of your change


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [ X] I read and followed [contribution rules](https://github.com/DivanteLtd/vsf-capybara/blob/master/CONTRIBUTING.md)