### PR TITLE
Implemented: master detail view on search page for Desktop (#148)

### DIFF
--- a/src/components/ProductListItem.vue
+++ b/src/components/ProductListItem.vue
@@ -1,5 +1,5 @@
 <template>
-  <ion-item button @click="viewProduct()" detail="true" lines="none">
+  <ion-item button detail="true" lines="none">
     <ion-thumbnail slot="start">
       <Image :src="product.mainImageUrl"/>
     </ion-thumbnail>
@@ -18,7 +18,6 @@ import {
   IonThumbnail,
   IonLabel
 } from '@ionic/vue'
-import { useRouter } from 'vue-router'
 import { useStore } from 'vuex';
 import Image from "@/components/Image.vue";
 
@@ -31,17 +30,10 @@ export default defineComponent({
     Image
   },
   props: ["product"],
-  methods: {
-    async viewProduct () {
-      this.router.push({ path: `/count/${this.product.sku}` })
-    }
-  },
   setup() {
-    const router = useRouter();
     const store = useStore();
     
     return {
-      router,
       store
     }
   },

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -42,6 +42,7 @@
   "Scan": "Scan",
   "Search": "Search",
   "Search time zones": "Search time zones",
+  "Search for a product and it will show up here": "Search for a product and it will show up here",
   "Select facility": "Select facility",
   "Select time zone": "Select time zone",
   "Set facility": "Set facility",

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -4,7 +4,6 @@ import Upload from "@/views/Upload.vue";
 import Settings from "@/views/Settings.vue";
 import store from "@/store";
 import Search from "@/views/Search.vue";
-import Count from "@/views/count.vue";
 import { hasPermission } from '@/authorization';
 import { showToast } from '@/utils'
 import { translate } from '@/i18n'
@@ -12,6 +11,7 @@ import { translate } from '@/i18n'
 import 'vue-router'
 import { Login, useAuthStore } from '@hotwax/dxp-components';
 import { loader } from '@/user-utils';
+import CountMobileView from '@/views/CountMobile.vue'
 
 // Defining types for the meta values
 declare module 'vue-router' {
@@ -64,7 +64,7 @@ const routes: Array<RouteRecordRaw> = [
   {
     path: "/count/:sku",
     name: "Count",
-    component: Count,
+    component: CountMobileView,
     beforeEnter: authGuard,
     props: true,
     meta: {

--- a/src/theme/variables.css
+++ b/src/theme/variables.css
@@ -79,6 +79,23 @@ http://ionicframework.com/docs/theming/ */
   --spacer-xs: 0.5rem;
 }
 
+.empty-state {
+  max-width: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 10px;
+}
+
+.empty-state > img {
+  object-fit: contain;
+}
+
+.empty-state > p {
+  text-align: center; 
+}
+
 @media (prefers-color-scheme: dark) {
   /*
    * Dark Colors

--- a/src/views/CountMobile.vue
+++ b/src/views/CountMobile.vue
@@ -1,0 +1,41 @@
+
+<template>
+  <ion-page>
+    <ion-header :translucent="true">
+      <ion-toolbar>
+        <ion-back-button slot="start" default-href="/"></ion-back-button>
+        <ion-title>{{ $t("Count") }}</ion-title>
+      </ion-toolbar>
+    </ion-header>
+
+    <ion-content>
+      <count :sku="$route.params.sku"></count>
+    </ion-content>
+  </ion-page>
+</template>
+  
+<script lang="ts">
+  import {
+    IonBackButton,
+    IonContent,
+    IonHeader,
+    IonPage,
+    IonTitle,
+    IonToolbar
+  } from "@ionic/vue";
+  import { defineComponent } from "vue";
+  import Count from "@/views/count.vue"
+  
+  export default defineComponent({
+    name: "CountMobileView",
+    components: {
+      IonBackButton,
+      IonContent,
+      IonHeader,
+      IonPage,
+      IonTitle,
+      IonToolbar,
+      Count
+    },
+  });
+</script>

--- a/src/views/count.vue
+++ b/src/views/count.vue
@@ -1,130 +1,114 @@
 <template>
-    <ion-page>
-      <ion-header :translucent="true">
-        <ion-toolbar>
-          <ion-back-button slot="start" default-href="/"></ion-back-button>
-          <ion-title>{{ $t("Count") }}</ion-title>
-        </ion-toolbar>
-      </ion-header>
-  
-      <ion-content>
-        <div class="product-image">
-            <Image :src="product.mainImageUrl"/>
-        </div>
-        
-        <div class="product-info">
-          <ion-item lines="none">
-            <ion-label>
-              <p class="overline">{{ product.productName }}</p>
-              <h2>{{ product.sku }}</h2>
-            </ion-label>
-          </ion-item>
-
-          <div class="product-features">
-            <ion-item lines="none">
-              <ion-chip v-if="$filters.getFeature(product.featureHierarchy, '1/COLOR/')">
-                <ion-icon :icon="colorPaletteOutline" />
-                <ion-label>{{ $filters.getFeature(product.featureHierarchy, '1/COLOR/') }}</ion-label>
-              </ion-chip>
-              <ion-chip v-if="$filters.getFeature(product.featureHierarchy, '1/SIZE/')">
-                <ion-icon :icon="resize" />
-                <ion-label>{{ $filters.getFeature(product.featureHierarchy, '1/SIZE/') }}</ion-label>
-              </ion-chip>
-            </ion-item>
-          </div>
-        </div>
-
-        <div class="segment" v-if="hasPermission(Actions.APP_INVNTRY_CNT_IMPORT) && hasPermission(Actions.APP_VARIANCE_LOG)">
-          <ion-segment v-model="segmentSelected">
-            <ion-segment-button v-if="hasPermission(Actions.APP_INVNTRY_CNT_IMPORT)" value="count">
-              <ion-label>{{ $t("Count") }}</ion-label>
-            </ion-segment-button>
-            <ion-segment-button v-if="hasPermission(Actions.APP_VARIANCE_LOG)" value="variance">
-              <ion-label>{{ $t("Variance") }}</ion-label>
-            </ion-segment-button>
-          </ion-segment>
-        </div>
-        
-        <div v-if="segmentSelected === 'count'" class="inventory-form">
-          <ion-item>
-            <ion-label position="floating">{{ $t("Stock") }}</ion-label>
-            <ion-input type="number" min="0" inputmode="numeric" :value="quantity" @ionChange="quantity = $event.detail.value" ></ion-input>
-          </ion-item>
-          <ion-item lines="none">
-            <ion-note id="stockCount">{{ $t("Enter the count of stock on the shelf.") }}</ion-note>
-          </ion-item>
-          <ion-item>
-            <ion-label>{{ $t("Location") }}</ion-label>
-            <ion-chip @click="selectLocation">
-              <ion-label>{{ location }}</ion-label>
-              <ion-icon :icon="locationOutline" />
-            </ion-chip>
-          </ion-item>
-          <ion-item v-if="viewQOH">
-            <ion-label>{{ $t("In stock") }}</ion-label>
-            <ion-label slot="end">{{ availableQOH }}</ion-label>
-          </ion-item>
-          <ion-item v-if="viewQOH">
-            <ion-label>{{ $t("Variance") }}</ion-label>
-            <ion-label slot="end">{{ availableQOH && quantity ? quantity - availableQOH : "-" }}</ion-label>
-          </ion-item>
+  <section>
+    <div class="product-image">
+        <Image :src="product.mainImageUrl"/>
+    </div>
     
-          <div class="action">
-            <ion-button size="large" :disabled="!hasPermission(Actions.APP_INVNTRY_CNT_IMPORT)" @click="updateProductInventoryCount()">
-              <ion-icon :icon="saveOutline" slot="start" />
-              {{$t("Save")}}
-            </ion-button>
-          </div>
-        </div>  
+    <div class="product-info">
+      <ion-item lines="none">
+        <ion-label>
+          <p class="overline">{{ product.productName }}</p>
+          <h2>{{ product.sku }}</h2>
+        </ion-label>
+      </ion-item>
 
-        <div v-else class="inventory-form">
-          <ion-item>
-            <ion-label position="floating">{{ $t("Quantity") }}</ion-label>
-            <ion-input type="number" inputmode="numeric" :placeholder="$t('inventory variance')" v-model="product.varianceQuantity" />
-          </ion-item>
-          <ion-item lines="none">
-            <ion-note id="stockCount">{{ $t("Enter the amount of stock that has changed.") }}</ion-note>
-          </ion-item>
+      <div class="product-features">
+        <ion-item lines="none">
+          <ion-chip v-if="$filters.getFeature(product.featureHierarchy, '1/COLOR/')">
+            <ion-icon :icon="colorPaletteOutline" />
+            <ion-label>{{ $filters.getFeature(product.featureHierarchy, '1/COLOR/') }}</ion-label>
+          </ion-chip>
+          <ion-chip v-if="$filters.getFeature(product.featureHierarchy, '1/SIZE/')">
+            <ion-icon :icon="resize" />
+            <ion-label>{{ $filters.getFeature(product.featureHierarchy, '1/SIZE/') }}</ion-label>
+          </ion-chip>
+        </ion-item>
+      </div>
+    </div>
 
-          <ion-item>
-            <ion-label>{{ $t("Variance reason") }}</ion-label>
-            <ion-select interface="popover" :value="product.varianceReasonId" @ionChange="updateVarianceReason($event)" :placeholder="$t('Select reason')" >
-              <ion-select-option v-for="reason in varianceReasons" :key="reason.enumId" :value="reason.enumId" >{{ reason.description }}</ion-select-option>
-            </ion-select>
-          </ion-item>
+    <div class="segment" v-if="hasPermission(Actions.APP_INVNTRY_CNT_IMPORT) && hasPermission(Actions.APP_VARIANCE_LOG)">
+      <ion-segment v-model="segmentSelected">
+        <ion-segment-button v-if="hasPermission(Actions.APP_INVNTRY_CNT_IMPORT)" value="count">
+          <ion-label>{{ $t("Count") }}</ion-label>
+        </ion-segment-button>
+        <ion-segment-button v-if="hasPermission(Actions.APP_VARIANCE_LOG)" value="variance">
+          <ion-label>{{ $t("Variance") }}</ion-label>
+        </ion-segment-button>
+      </ion-segment>
+    </div>
+    
+    <div v-if="segmentSelected === 'count'" class="inventory-form">
+      <ion-item>
+        <ion-label position="floating">{{ $t("Stock") }}</ion-label>
+        <ion-input type="number" min="0" inputmode="numeric" :value="quantity" @ionChange="quantity = $event.detail.value" ></ion-input>
+      </ion-item>
+      <ion-item lines="none">
+        <ion-note id="stockCount">{{ $t("Enter the count of stock on the shelf.") }}</ion-note>
+      </ion-item>
+      <ion-item>
+        <ion-label>{{ $t("Location") }}</ion-label>
+        <ion-chip @click="selectLocation">
+          <ion-label>{{ location }}</ion-label>
+          <ion-icon :icon="locationOutline" />
+        </ion-chip>
+      </ion-item>
+      <ion-item v-if="viewQOH">
+        <ion-label>{{ $t("In stock") }}</ion-label>
+        <ion-label slot="end">{{ availableQOH }}</ion-label>
+      </ion-item>
+      <ion-item v-if="viewQOH">
+        <ion-label>{{ $t("Variance") }}</ion-label>
+        <ion-label slot="end">{{ availableQOH && quantity ? quantity - availableQOH : "-" }}</ion-label>
+      </ion-item>
 
-          <div class="action">
-            <ion-button size="large" @click="confirmVarianceUpdate()">
-              <ion-icon :icon="cloudUploadOutline" slot="start" />
-              {{$t("Log variance")}}
-            </ion-button>
-          </div>
-        </div>
+      <div class="action">
+        <ion-button size="large" :disabled="!hasPermission(Actions.APP_INVNTRY_CNT_IMPORT)" @click="updateProductInventoryCount()">
+          <ion-icon :icon="saveOutline" slot="start" />
+          {{$t("Save")}}
+        </ion-button>
+      </div>
+    </div>  
 
-      </ion-content>
-    </ion-page>
-  </template>
+    <div v-else class="inventory-form">
+      <ion-item>
+        <ion-label position="floating">{{ $t("Quantity") }}</ion-label>
+        <ion-input type="number" inputmode="numeric" :placeholder="$t('inventory variance')" v-model="product.varianceQuantity" />
+      </ion-item>
+      <ion-item lines="none">
+        <ion-note id="stockCount">{{ $t("Enter the amount of stock that has changed.") }}</ion-note>
+      </ion-item>
+
+      <ion-item>
+        <ion-label>{{ $t("Variance reason") }}</ion-label>
+        <ion-select interface="popover" :value="product.varianceReasonId" @ionChange="updateVarianceReason($event)" :placeholder="$t('Select reason')" >
+          <ion-select-option v-for="reason in varianceReasons" :key="reason.enumId" :value="reason.enumId" >{{ reason.description }}</ion-select-option>
+        </ion-select>
+      </ion-item>
+
+      <div class="action">
+        <ion-button size="large" @click="confirmVarianceUpdate()">
+          <ion-icon :icon="cloudUploadOutline" slot="start" />
+          {{$t("Log variance")}}
+        </ion-button>
+      </div>
+    </div>
+  </section>
+</template>
   
   <script lang="ts">
   import {
     alertController,
-    IonBackButton,
     IonButton,
     IonChip,
-    IonContent,
-    IonHeader,
     IonIcon,
     IonInput,
     IonItem,
     IonLabel,
     IonNote,
-    IonPage,
     IonSegment,
     IonSelect,
     IonSelectOption,
     IonSegmentButton,
-    IonTitle,
-    IonToolbar,
     pickerController
   } from "@ionic/vue";
   import { defineComponent } from "vue";
@@ -143,23 +127,17 @@
   export default defineComponent({
     name: "Count",
     components: {
-      IonBackButton,
       IonButton,
       IonChip,
-      IonContent,
-      IonHeader,
       IonIcon,
       IonInput,
       IonItem,
       IonLabel,
       IonNote,
-      IonPage,
       IonSegment,
       IonSegmentButton,
       IonSelect,
       IonSelectOption,
-      IonTitle,
-      IonToolbar,
       Image
     },
     computed: {
@@ -179,9 +157,10 @@
         quantity: 0 as any
       }
     },
+    props: ['sku'],
     async mounted(){
       await this.fetchVarianceReasons();
-      await this.store.dispatch("product/updateCurrentProduct", this.$route.params.sku);
+      await this.store.dispatch("product/updateCurrentProduct", this.sku);
       this.quantity = this.product.quantity
       await this.getFacilityLocations();
       if (this.viewQOH) await this.getInventory()

--- a/src/views/count.vue
+++ b/src/views/count.vue
@@ -1,7 +1,7 @@
 <template>
   <section>
     <div class="product-image">
-        <Image :src="product.mainImageUrl"/>
+      <Image :src="product.mainImageUrl"/>
     </div>
     
     <div class="product-info">


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

Closes #148

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
Made count view reusable and created CountMobile view to render count component in it in case of Mobile Display.
In case of Desktop Display rendering count component in search view itself.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->
**For Desktop screen -** 
[Screencast from 17-08-23 02:43:25 PM IST.webm](https://github.com/hotwax/inventory-count/assets/67117461/d1045aa4-0fe1-4f46-a4df-2d61ec11512f)

**For Mobile Screen -**
[Screencast from 17-08-23 02:45:27 PM IST.webm](https://github.com/hotwax/inventory-count/assets/67117461/c6f0cb65-87ff-4bf8-9572-0bf8685eec88)

### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I have read and followed [contribution rules](https://github.com/hotwax/inventory-count#contribution-guideline)
