### PR TITLE
Implemented: product store selector in settings (#193)

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1,4 +1,5 @@
 {
+  "A store represents a company or a unique catalog of products. If your OMS is connected to multiple eCommerce stores selling different collections of products, you may have multiple Product Stores set up in HotWax Commerce.": "A store represents a company or a unique catalog of products. If your OMS is connected to multiple eCommerce stores selling different collections of products, you may have multiple Product Stores set up in HotWax Commerce.",
   "App": "App",
   "Are you sure you want to change the time zone to?": "Are you sure you want to change the time zone to {timeZoneId}?",
   "Authenticating": "Authenticating",
@@ -34,6 +35,7 @@
   "OMS": "OMS",
   "OMS instance": "OMS instance",
   "Password": "Password",
+  "Product Store": "Product Store",
   "Product not found": "Product not found",
   "Quantity": "Quantity",
   "Quantity on hand": "Quantity on hand",
@@ -54,6 +56,8 @@
   "Specify which facility you want to operate from. Order, inventory and other configuration data will be specific to the facility you select.": "Specify which facility you want to operate from. Order, inventory and other configuration data will be specific to the facility you select.",
   "Stock": "Stock",
   "Select reason": "Select reason",
+  "Select store": "Select store",
+  "Store": "Store",
   "store name":"store name",
   "Results": "Results",
   "The inventory will be immediately updated and cannot be undone. Are you sure you want to update the inventory variance?": "The inventory will be immediately updated and cannot be undone. Are you sure you want to update the inventory variance?",

--- a/src/views/Settings.vue
+++ b/src/views/Settings.vue
@@ -51,6 +51,29 @@
             <ion-icon slot="end" :icon="openOutline" />
           </ion-button>
         </ion-card>
+
+        <ion-card>
+          <ion-card-header>
+            <ion-card-subtitle>
+              {{ $t("Product Store") }}
+            </ion-card-subtitle>
+            <ion-card-title>
+              {{ $t("Store") }}
+            </ion-card-title>
+          </ion-card-header>
+
+          <ion-card-content>
+            {{ $t('A store represents a company or a unique catalog of products. If your OMS is connected to multiple eCommerce stores selling different collections of products, you may have multiple Product Stores set up in HotWax Commerce.') }}
+          </ion-card-content>
+
+          <ion-item lines="none">
+            <ion-label> {{ $t("Select store") }} </ion-label>
+            <ion-select interface="popover" :placeholder="$t('store name')" :value="currentEComStore.productStoreId" @ionChange="setEComStore($event)">
+              <ion-select-option v-for="store in (userProfile ? userProfile.stores : [])" :key="store.productStoreId" :value="store.productStoreId" >{{ store.storeName }}</ion-select-option>
+            </ion-select>
+          </ion-item>
+        </ion-card>
+
         <ion-card>
           <ion-card-header>
             <ion-card-title>
@@ -204,6 +227,13 @@ export default defineComponent({
       }
       // Fetch the updated configuration
       await this.getViewQOHConfig();
+    },
+    setEComStore(store: any) {
+      if(this.userProfile) {
+        this.store.dispatch('user/setEComStore', {
+          'eComStore': this.userProfile.stores.find((str: any) => str.productStoreId == store['detail'].value)
+        })
+      }
     },
     setFacility (event: any) {
       // adding check for this.currentFacility.facilityId as it gets set to undefined on logout


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

Closes #193

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
- created user service to get the preferred store, get ecom stores, and set user preferences.
- created a new user action to set ecomstore.
- changes in settings for ecomstore selector.

### Steps to verify -
- Product store selection works properly.
- Proper API call for setting user preference.
- On changing facility available stores changes.
- Case when a user is not associated with any facility.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->
![newnew](https://github.com/hotwax/inventory-count/assets/67117461/7281d783-5225-4b24-830c-d4a8bdcd74b3)


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I have read and followed [contribution rules](https://github.com/hotwax/inventory-count#contribution-guideline)
