### PR TITLE
Added functionality to add a toast msg on item removal Fixes Issue #213

### DIFF
--- a/src/views/Upload.vue
+++ b/src/views/Upload.vue
@@ -72,6 +72,8 @@ import { mapGetters, useStore } from 'vuex';
 import { useRouter } from 'vue-router';
 import { ShopifyImg } from '@hotwax/dxp-components';
   import { Actions, hasPermission } from '@/authorization'
+import { showToast } from '@/utils';
+import { translate } from '@/i18n';
 
 export default defineComponent({
   name: "Upload",
@@ -103,6 +105,7 @@ export default defineComponent({
   methods: {
     removeItem (sku: any) {
       this.store.dispatch('product/removeItemFromUploadProducts', sku)
+      showToast(translate("The item has Sucessfully Removed!"))
     },
     async presentAlertOnUpload() {
       const alert = await alertController.create({


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->
When a user removes an item from the Upload page, it is essential to provide feedback to confirm the successful removal. Adding a toast notification will enhance the user experience by providing instant visual feedback, ensuring users are aware of the action's outcome.

Closes #213 

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
I have imported the showToast function in `src/views/Upload.vue` from `src/utils/index.ts` and on sucessful removal of item it shows an appropiate toast message!

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->
![Screenshot (136)](https://github.com/hotwax/inventory-count/assets/114515612/40129a2e-f9d6-4b73-a028-509d0ba880b8)

"when the user removes, this toast message will be shown"

### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I have read and followed [contribution rules](https://github.com/hotwax/inventory-count#contribution-guideline)
