### PR TITLE
Made the upload chip hoverable, now user know that it is button.

### DIFF
--- a/src/views/Upload.vue
+++ b/src/views/Upload.vue
@@ -38,8 +38,8 @@
           </ion-item>
         <ion-button fill="clear" @click="removeItem(product.sku)">{{ $t( "Remove" ) }}</ion-button>
       </ion-card>
-      <ion-fab vertical="bottom" horizontal="end" slot="fixed">
-        <ion-fab-button @click="presentAlertOnUpload()" :disabled="!hasPermission(Actions.APP_INVNTRY_CNT_IMPORT) || Object.keys(uploadProducts).length === 0">
+      <ion-fab style="cursor: pointer" vertical="bottom" horizontal="end" slot="fixed">
+        <ion-fab-button @click="presentAlertOnUpload()" :disabled="!hasPermission(Actions.APP_INVNTRY_CNT_IMPORT) ||Object.keys(uploadProducts).length === 0">
           <ion-icon :icon="cloudUploadOutline" />
         </ion-fab-button>
       </ion-fab>


### PR DESCRIPTION
### Related Issues
Issue #208 

Closes #

### Short Description and Why It's Useful
Fix the Pointer over the chip of upload as it make it like the button is not a actionable button. so when Now we hover it. it changes the pointer.


### Screenshots of Visual Changes before/after (If There Are Any)
Before
![image](https://github.com/hotwax/inventory-count/assets/44457947/bc30997b-ba25-4992-b4f4-e1426ba64afa)

After 
![image](https://github.com/hotwax/inventory-count/assets/44457947/9db45136-b183-4501-a879-4f179c028633)



### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I have read and followed [contribution rules](https://github.com/hotwax/inventory-count#contribution-guideline)
