### PR TITLE
Fixed: When calling getPermissions api duplicate permissionIds are passed in the payload(#211)

### DIFF
--- a/src/store/modules/user/actions.ts
+++ b/src/store/modules/user/actions.ts
@@ -31,7 +31,9 @@ const actions: ActionTree<UserState, RootState> = {
       const permissionId = process.env.VUE_APP_PERMISSION_ID;
       // Prepare permissions list
       const serverPermissionsFromRules = getServerPermissionsFromRules();
-      if (permissionId) serverPermissionsFromRules.push(permissionId);
+      
+      const removeDuplicatePermissionIds = new Set(serverPermissionsFromRules)
+      removeDuplicatePermissionIds.add(permissionId);
 
       const serverPermissions = await UserService.getUserPermissions({
         permissionIds: serverPermissionsFromRules

--- a/src/store/modules/user/actions.ts
+++ b/src/store/modules/user/actions.ts
@@ -31,12 +31,10 @@ const actions: ActionTree<UserState, RootState> = {
       const permissionId = process.env.VUE_APP_PERMISSION_ID;
       // Prepare permissions list
       const serverPermissionsFromRules = getServerPermissionsFromRules();
-      
-      const removeDuplicatePermissionIds = new Set(serverPermissionsFromRules)
-      removeDuplicatePermissionIds.add(permissionId);
+      if (permissionId) serverPermissionsFromRules.push(permissionId);
 
       const serverPermissions = await UserService.getUserPermissions({
-        permissionIds: serverPermissionsFromRules
+        permissionIds: [...new Set(serverPermissionsFromRules)]
       }, token);
       const appPermissions = prepareAppPermissions(serverPermissions);
 


### PR DESCRIPTION


### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

Closes #211 

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->

### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [ ] I have read and followed [contribution rules](https://github.com/hotwax/inventory-count#contribution-guideline)
