### PR TITLE
Improved: Added support to set userLoginId as comments/description while recording variance.

### DIFF
--- a/src/views/count.vue
+++ b/src/views/count.vue
@@ -163,7 +163,8 @@
       ...mapGetters({
         product: "product/getCurrent",
         facility: 'user/getCurrentFacility',
-        QOHConfig: 'user/getViewQOHConfig'
+        QOHConfig: 'user/getViewQOHConfig',
+        userProfile: 'user/getUserProfile',
       })
     },
     data(){
@@ -365,7 +366,8 @@
               "quantity": parseInt(this.product.varianceQuantity),
               "facilityId": this.facility.facilityId,
               "locationSeqId": this.product.locationId,
-              "varianceReasonId": this.product.varianceReasonId
+              "varianceReasonId": this.product.varianceReasonId,
+              "comments": this.userProfile.userLoginId
             }
           }
 


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

Closes #265

### Short Description and Why It's Useful
Improved: Added support to set userLoginId as comments/description while recording variance.


### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [ ] I have read and followed [contribution rules](https://github.com/hotwax/inventory-count#contribution-guideline)
