### PR TITLE
Fixed: infinite scroll issue when used with searchbar(dxp-289) 

### DIFF
--- a/src/views/Search.vue
+++ b/src/views/Search.vue
@@ -19,7 +19,13 @@
         <ion-list-header>{{ $t("Results") }}</ion-list-header>
 
         <product-list-item v-for="product in products" :key="product.productId" :product="product"/>
-
+        <!--
+          When searching for a keyword, and if the user moves to the last item, then the didFire value inside infinite scroll becomes true and thus the infinite scroll does not trigger again on the same page(https://github.com/hotwax/users/issues/84).
+          In ionic v7.6.0, an issue related to infinite scroll has been fixed that when more items can be added to the DOM, but infinite scroll does not fire as the window is not completely filled with the content(https://github.com/ionic-team/ionic-framework/issues/18071).
+          The above fix in ionic 7.6.0 is resulting in the issue of infinite scroll not being called again.
+          To fix this, we have added a key with value as queryString(searched keyword), so that the infinite scroll component can be re-rendered
+          whenever the searched string is changed resulting in the correct behaviour for infinite scroll
+        -->
         <ion-infinite-scroll @ionInfinite="loadMoreProducts($event)" threshold="100px" :disabled="!isScrollable" :key="queryString">
           <ion-infinite-scroll-content loading-spinner="crescent" :loading-text="$t('Loading')"></ion-infinite-scroll-content>
         </ion-infinite-scroll>

--- a/src/views/Search.vue
+++ b/src/views/Search.vue
@@ -5,7 +5,7 @@
         <ion-title>{{ $t("Cycle Count") }}</ion-title>
       </ion-toolbar>
     </ion-header>
-    <ion-content>
+    <ion-content ref="contentRef" :scroll-events="true" @ionScroll="enableScrolling()">
       <ion-searchbar @ionFocus="selectSearchBarText($event)" v-model="queryString" :placeholder="$t('Search')" @keyup.enter="queryString = $event.target.value; searchProducts()"/>
       
       <!-- Empty state -->
@@ -21,12 +21,14 @@
         <product-list-item v-for="product in products" :key="product.productId" :product="product"/>
         <!--
           When searching for a keyword, and if the user moves to the last item, then the didFire value inside infinite scroll becomes true and thus the infinite scroll does not trigger again on the same page(https://github.com/hotwax/users/issues/84).
+          Also if we are at the section that has been loaded by infinite-scroll and then move to the details page then the list infinite scroll does not work after coming back to the page
           In ionic v7.6.0, an issue related to infinite scroll has been fixed that when more items can be added to the DOM, but infinite scroll does not fire as the window is not completely filled with the content(https://github.com/ionic-team/ionic-framework/issues/18071).
           The above fix in ionic 7.6.0 is resulting in the issue of infinite scroll not being called again.
-          To fix this, we have added a key with value as queryString(searched keyword), so that the infinite scroll component can be re-rendered
-          whenever the searched string is changed resulting in the correct behaviour for infinite scroll
+          To fix this we have maintained another variable `isScrollingEnabled` to check whether the scrolling can be performed or not.
+          If we do not define an extra variable and just use v-show to check for `isScrollable` then when coming back to the page infinite-scroll is called programatically.
+          We have added an ionScroll event on ionContent to check whether the infiniteScroll can be enabled or not by toggling the value of isScrollingEnabled whenever the height < 0.
         -->
-        <ion-infinite-scroll @ionInfinite="loadMoreProducts($event)" threshold="100px" :disabled="!isScrollable" :key="queryString">
+        <ion-infinite-scroll @ionInfinite="loadMoreProducts($event)" threshold="100px" v-show="isScrollingEnabled && isScrollable" ref="infiniteScrollRef">
           <ion-infinite-scroll-content loading-spinner="crescent" :loading-text="$t('Loading')"></ion-infinite-scroll-content>
         </ion-infinite-scroll>
       </ion-list>
@@ -96,7 +98,8 @@ export default defineComponent({
     return {
       queryString: '',
       showErrorMessage: false,
-      fetchingProducts: false
+      fetchingProducts: false,
+      isScrollingEnabled: false
     }
   },
   computed: {
@@ -106,6 +109,7 @@ export default defineComponent({
     })
   },
   ionViewWillEnter(){
+    this.isScrollingEnabled = false;
     if(this.$route.redirectedFrom) this.queryString = '';
   },
   methods: {
@@ -136,13 +140,24 @@ export default defineComponent({
         element.select();
       })
     },
+    enableScrolling() {
+      const parentElement = (this as any).$refs.contentRef.$el
+      const scrollEl = parentElement.shadowRoot.querySelector("main[part='scroll']")
+      let scrollHeight = scrollEl.scrollHeight, infiniteHeight = (this as any).$refs.infiniteScrollRef.$el.offsetHeight, scrollTop = scrollEl.scrollTop, threshold = 100, height = scrollEl.offsetHeight
+      const distanceFromInfinite = scrollHeight - infiniteHeight - scrollTop - threshold - height
+      if(distanceFromInfinite < 0) {
+        this.isScrollingEnabled = false;
+      } else {
+        this.isScrollingEnabled = true;
+      }
+    },
     async loadMoreProducts (event: any) {
       this.searchProducts(
         undefined,
         Math.ceil(this.products.length / process.env.VUE_APP_VIEW_SIZE).toString()
-      ).then(() => {
-        event.target.complete();
-      })
+      ).then(async () => {
+        await event.target.complete();
+      });
     },
     async searchProducts(vSize?: any, vIndex?: any) {
       this.queryString ? this.showErrorMessage = true : this.showErrorMessage = false;

--- a/src/views/Search.vue
+++ b/src/views/Search.vue
@@ -20,7 +20,7 @@
 
         <product-list-item v-for="product in products" :key="product.productId" :product="product"/>
 
-        <ion-infinite-scroll @ionInfinite="loadMoreProducts($event)" threshold="100px" :disabled="!isScrollable">
+        <ion-infinite-scroll @ionInfinite="loadMoreProducts($event)" threshold="100px" :disabled="!isScrollable" :key="queryString">
           <ion-infinite-scroll-content loading-spinner="crescent" :loading-text="$t('Loading')"></ion-infinite-scroll-content>
         </ion-infinite-scroll>
       </ion-list>


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->
https://github.com/hotwax/dxp-components/issues/289

### Short Description and Why It's Useful
Removed the logic to re-render the infinite-scroll on queryString check that has been added in the previous PR.

Added a variable to check whether the scrolling can be enabled or not whenever users lands on the list page. For this, we have determined the height of the content part scroll and infiniteScroll component and if the height is less than 0 then only enabling the infinite-scroll component

Removed disabled as once the infiniteScroll is disabled it does not gets enabled again, hence removed the disabled property and instead used v-show to enable/disable infinite scroll.




### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I have read and followed [contribution rules](https://github.com/hotwax/inventory-count#contribution-guideline)
