### PR TITLE
Fixed: Infinite scroll with searchbar and loading bug(#289)

### DIFF
--- a/src/views/Search.vue
+++ b/src/views/Search.vue
@@ -154,7 +154,7 @@ export default defineComponent({
     async loadMoreProducts (event: any) {
       // Added this check here as if added on infinite-scroll component the Loading content does not gets displayed
       if(!(this.isScrollingEnabled && this.isScrollable)) {
-       await event.target.complete();
+        await event.target.complete();
       }  
       this.searchProducts(
         undefined,

--- a/src/views/Search.vue
+++ b/src/views/Search.vue
@@ -28,7 +28,7 @@
           If we do not define an extra variable and just use v-show to check for `isScrollable` then when coming back to the page infinite-scroll is called programatically.
           We have added an ionScroll event on ionContent to check whether the infiniteScroll can be enabled or not by toggling the value of isScrollingEnabled whenever the height < 0.
         -->
-        <ion-infinite-scroll @ionInfinite="loadMoreProducts($event)" threshold="100px" v-show="isScrollingEnabled && isScrollable" ref="infiniteScrollRef">
+        <ion-infinite-scroll @ionInfinite="loadMoreProducts($event)" threshold="100px" v-show="isScrollable" ref="infiniteScrollRef">
           <ion-infinite-scroll-content loading-spinner="crescent" :loading-text="$t('Loading')"></ion-infinite-scroll-content>
         </ion-infinite-scroll>
       </ion-list>
@@ -152,6 +152,10 @@ export default defineComponent({
       }
     },
     async loadMoreProducts (event: any) {
+      // Added this check here as if added on infinite-scroll component the Loading content does not gets displayed
+      if(!(this.isScrollingEnabled && this.isScrollable)) {
+       await event.target.complete();
+      }  
       this.searchProducts(
         undefined,
         Math.ceil(this.products.length / process.env.VUE_APP_VIEW_SIZE).toString()


### PR DESCRIPTION


### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

https://github.com/hotwax/dxp-components/issues/289
### Short Description and Why It's Useful
Removed the logic to re-render the infinite-scroll on queryString check that has been added in the previous PR.

Added a variable to check whether the scrolling can be enabled or not whenever users lands on the list page. For this, we have determined the height of the content part scroll and infiniteScroll component and if the height is less than 0 then only enabling the infinite-scroll component

Removed disabled as once the infiniteScroll is disabled it does not gets enabled again, hence removed the disabled property and instead used v-show to enable/disable infinite scroll.



### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I have read and followed [contribution rules](https://github.com/hotwax/inventory-count#contribution-guideline)
