### PR TITLE
Removed: support to pass createdDate when creating a new count

### DIFF
--- a/src/views/Draft.vue
+++ b/src/views/Draft.vue
@@ -115,8 +115,7 @@ async function createCycleCount() {
       // When initially creating the cycleCount we are just assigning it a name, all the other params are updated from the details page
       await store.dispatch("count/createCycleCount", {
         countImportName: name,
-        statusId: "INV_COUNT_CREATED",
-        createdDate: DateTime.now().toMillis()
+        statusId: "INV_COUNT_CREATED"
       })
     }
   })


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
Added support to pass createdDate using the server time when creating a new route, thus removed support to pass created date from app

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I have read and followed [contribution rules](https://github.com/hotwax/inventory-count#contribution-guideline)
