### PR TITLE
Improved: added sticky scrolling on the counting page(#353)

### DIFF
--- a/src/views/CountDetail.vue
+++ b/src/views/CountDetail.vue
@@ -9,46 +9,48 @@
     <ion-content>
       <div class="find">
         <aside class="filters">
-          <ion-item lines="full" class="ion-margin-top">
-            <ion-input :label="translate('SKU')" :placeholder="translate('Scan or search products')" @ionFocus="selectSearchBarText($event)" v-model="queryString" @keyup.enter="searchProducts()"/>
-          </ion-item>
-          <ion-segment v-model="selectedSegment" @ionChange="updateFilteredItems()">
-            <template v-if="cycleCount?.statusId === 'INV_COUNT_CREATED'">
-              <ion-segment-button value="all">
-                <ion-label>{{ translate("ALL") }}</ion-label>
-              </ion-segment-button>
-              <ion-segment-button value="pending">
-                <ion-label>{{ translate("PENDING") }}</ion-label>
-              </ion-segment-button>
-              <ion-segment-button value="counted">
-                <ion-label>{{ translate("COUNTED") }}</ion-label>
-              </ion-segment-button>
-            </template>
-
-            <template v-else-if="cycleCount?.statusId === 'INV_COUNT_REVIEW'">
-              <ion-segment-button value="all">
-                <ion-label>{{ translate("ALL") }}</ion-label>
-              </ion-segment-button>
-              <ion-segment-button value="notCounted">
-                <ion-label>{{ translate("NOT COUNTED") }}</ion-label>
-              </ion-segment-button>
-              <ion-segment-button value="counted">
-                <ion-label>{{ translate("COUNTED") }}</ion-label>
-              </ion-segment-button>
-            </template>
-
-            <template v-else-if="cycleCount?.statusId === 'INV_COUNT_COMPLETED' && 'INV_COUNT_REJECTED'">
-              <ion-segment-button value="all">
-                <ion-label>{{ translate("ALL") }}</ion-label>
-              </ion-segment-button>
-              <ion-segment-button value="rejected">
-                <ion-label>{{ translate("REJECTED") }}</ion-label>
-              </ion-segment-button>
-              <ion-segment-button value="accepted">
-                <ion-label>{{ translate("ACCEPTED") }}</ion-label>
-              </ion-segment-button>
-            </template> 
-          </ion-segment>
+          <div class="fixed-section">
+            <ion-item lines="full">
+              <ion-input :label="translate('SKU')" :placeholder="translate('Scan or search products')" @ionFocus="selectSearchBarText($event)" v-model="queryString" @keyup.enter="searchProducts()"/>
+            </ion-item>
+            <ion-segment v-model="selectedSegment" @ionChange="updateFilteredItems()">
+              <template v-if="cycleCount?.statusId === 'INV_COUNT_ASSIGNED'">
+                <ion-segment-button value="all">
+                  <ion-label>{{ translate("ALL") }}</ion-label>
+                </ion-segment-button>
+                <ion-segment-button value="pending">
+                  <ion-label>{{ translate("PENDING") }}</ion-label>
+                </ion-segment-button>
+                <ion-segment-button value="counted">
+                  <ion-label>{{ translate("COUNTED") }}</ion-label>
+                </ion-segment-button>
+              </template>
+  
+              <template v-else-if="cycleCount?.statusId === 'INV_COUNT_REVIEW'">
+                <ion-segment-button value="all">
+                  <ion-label>{{ translate("ALL") }}</ion-label>
+                </ion-segment-button>
+                <ion-segment-button value="notCounted">
+                  <ion-label>{{ translate("NOT COUNTED") }}</ion-label>
+                </ion-segment-button>
+                <ion-segment-button value="counted">
+                  <ion-label>{{ translate("COUNTED") }}</ion-label>
+                </ion-segment-button>
+              </template>
+  
+              <template v-else-if="cycleCount?.statusId === 'INV_COUNT_COMPLETED' && 'INV_COUNT_REJECTED'">
+                <ion-segment-button value="all">
+                  <ion-label>{{ translate("ALL") }}</ion-label>
+                </ion-segment-button>
+                <ion-segment-button value="rejected">
+                  <ion-label>{{ translate("REJECTED") }}</ion-label>
+                </ion-segment-button>
+                <ion-segment-button value="accepted">
+                  <ion-label>{{ translate("ACCEPTED") }}</ion-label>
+                </ion-segment-button>
+              </template> 
+            </ion-segment>
+          </div>
           <template v-if="filteredItems.length > 0">
             <ProductItemList v-for="item in filteredItems" :key="item.inventoryCountImportId" :item="item"/>
           </template>
@@ -215,6 +217,17 @@ onIonViewWillLeave(() => {
 ion-content > main {
   display: grid;
   height: 100%;
+}
+
+.fixed-section {
+  position: sticky;
+  top: 0;
+  background: var(--ion-background-color, #fff);
+  z-index: 1000;
+}
+
+aside {
+  overflow-y: scroll;
 }
 
 @media (min-width: 991px) {

--- a/src/views/ProductDetail.vue
+++ b/src/views/ProductDetail.vue
@@ -231,6 +231,11 @@
   </script>
 
   <style>
+
+  main{
+    overflow-y: hidd;
+  }
+
   .product-info {
     width: 100%;
     margin-top: var(--spacer-lg);

--- a/src/views/ProductDetail.vue
+++ b/src/views/ProductDetail.vue
@@ -233,7 +233,7 @@
   <style>
 
   main{
-    overflow-y: hidd;
+    overflow-y: hidden;
   }
 
   .product-info {


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#353 

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
- Added sticky scrolling on the counting page.
- Scrolling is working on the items list and the searchbar/ segments are fixed in position.
- The product details section is also not scrolling with list scroll.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->
![Screenshot from 2024-07-15 20-33-21](https://github.com/user-attachments/assets/f02af55a-a556-4985-adb7-adda6a8242d4)


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I have read and followed [contribution rules](https://github.com/hotwax/inventory-count#contribution-guideline)
