### PR TITLE
Fixed: case to always move to count page when moving from settings page in store view screen(#356)

### DIFF
--- a/src/views/Tabs.vue
+++ b/src/views/Tabs.vue
@@ -3,7 +3,7 @@
     <ion-tabs>
       <ion-router-outlet></ion-router-outlet>
       <ion-tab-bar slot="bottom">
-        <ion-tab-button tab="orders" href="/tabs/count">
+        <ion-tab-button tab="orders" @click="$router.push('/tabs/count')" href="/tabs/count">
           <ion-icon :icon="infiniteOutline" />
           <ion-label>{{ translate("Counts") }}</ion-label>
         </ion-tab-button>


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#356 

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->


### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I have read and followed [contribution rules](https://github.com/hotwax/inventory-count#contribution-guideline)
