### PR TITLE
Improved: code to fetch only the associated facilities when users does not have admin permissions(#352)

### DIFF
--- a/src/store/modules/user/actions.ts
+++ b/src/store/modules/user/actions.ts
@@ -10,7 +10,7 @@ import { Settings } from "luxon";
 import { resetConfig } from "@/adapter"
 import { useAuthStore } from "@hotwax/dxp-components"
 import emitter from "@/event-bus"
-import { getServerPermissionsFromRules, prepareAppPermissions, resetPermissions, setPermissions } from "@/authorization"
+import { getServerPermissionsFromRules, hasPermission, prepareAppPermissions, resetPermissions, setPermissions } from "@/authorization"
 
 const actions: ActionTree<UserState, RootState> = {
 
@@ -140,26 +140,39 @@ const actions: ActionTree<UserState, RootState> = {
     let facilities: Array<any> = []
     try {
       let associatedFacilityIds: Array<string> = []
-      const associatedFacilitiesResp = await UserService.fetchAssociatedFacilities({
-        partyId: (state.current as any).partyId,
-        pageSize: 200
-      })
+      let params = {}
 
-      if(!hasError(associatedFacilitiesResp)) {
-        // Filtering facilities on which thruDate is set, as we are unable to pass thruDate check in the api payload
-        // Considering that the facilities will always have a thruDate of the past.
-        associatedFacilityIds = associatedFacilitiesResp.data.filter((facility: any) => !facility.thruDate)?.map((facility: any) => facility.facilityId)
-      }
+      if(!hasPermission("APP_DRAFT_VIEW")) {
+        const associatedFacilitiesResp = await UserService.fetchAssociatedFacilities({
+          partyId: (state.current as any).partyId,
+          pageSize: 200
+        })
 
-      if(!associatedFacilityIds.length) {
-        throw "Failed to fetch facilities"
+        if(!hasError(associatedFacilitiesResp)) {
+          // Filtering facilities on which thruDate is set, as we are unable to pass thruDate check in the api payload
+          // Considering that the facilities will always have a thruDate of the past.
+          associatedFacilityIds = associatedFacilitiesResp.data.filter((facility: any) => !facility.thruDate)?.map((facility: any) => facility.facilityId)
+        }
+
+        if(!associatedFacilityIds.length) {
+          throw "Failed to fetch facilities"
+        }
+
+        params = {
+          facilityId: associatedFacilityIds.join(","),
+          facilityId_op: "in",
+          pageSize: associatedFacilityIds.length,
+        }
       }
 
       // Making this call to fetch the facility details like name, as the above api does not return facility details, need to replace this once api has support to return facility details
       const resp = await UserService.fetchFacilities({
-        facilityId: associatedFacilityIds.join(","),
-        facilityId_op: "in",
-        pageSize: associatedFacilityIds.length
+        parentTypeId: "VIRTUAL_FACILITY",
+        parentTypeId_not: "Y",
+        facilityTypeId: "VIRTUAL_FACILITY",
+        facilityTypeId_not: "Y",
+        pageSize: 200,
+        ...params
       })
 
       if(!hasError(resp)) {


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#352

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
Fetching the users associated facilities only when user does not have admin screen permission, as in this case we need to display all the facilities for assigning to count.

Related PR: https://github.com/hotwax/inventory-count/pull/383

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I have read and followed [contribution rules](https://github.com/hotwax/inventory-count#contribution-guideline)
