### PR TITLE
Improved: item with a 0 inventory count should be saved correctly and will not be pending in the Assigned section(#377)

### DIFF
--- a/src/views/ProductItemList.vue
+++ b/src/views/ProductItemList.vue
@@ -14,13 +14,13 @@
     <ion-note v-else-if="item.itemStatusId === 'INV_COUNT_COMPLETED'" color="success">
       {{ translate("accepted") }}
     </ion-note>
-    <ion-badge slot="end" v-else-if="item.quantity && item.statusId === 'INV_COUNT_ASSIGNED'">
+    <ion-badge slot="end" v-else-if="item.quantity >= 0 && item.statusId === 'INV_COUNT_ASSIGNED'">
       {{ item.quantity }} {{ translate("units") }}
     </ion-badge>
-    <ion-note v-else-if="!item.quantity && item.statusId === 'INV_COUNT_ASSIGNED'">
+    <ion-note v-else-if="item.quantity === undefined || item.quantity === null && item.statusId === 'INV_COUNT_ASSIGNED'">
       {{ translate("pending") }}
     </ion-note>
-    <ion-note v-else-if="item.quantity > 0 && item.statusId === 'INV_COUNT_REVIEW'">
+    <ion-note v-else-if="item.quantity >= 0 && item.statusId === 'INV_COUNT_REVIEW'">
       {{ translate("pending review") }}
     </ion-note>
     <ion-note v-else-if="!item.quantity && item.statusId === 'INV_COUNT_REVIEW'" color="warning">

--- a/src/views/ProductItemList.vue
+++ b/src/views/ProductItemList.vue
@@ -9,7 +9,7 @@
       <p>{{ getProductIdentificationValue(productStoreSettings["productIdentificationPref"].secondaryId, getProduct(item.productId)) }}</p>
     </ion-label>
     <ion-badge slot="end" color="danger" v-if="item.itemStatusId === 'INV_COUNT_REJECTED'">
-      {{ item.quantity ? item.quantity : "-" }} {{ translate("units") }}
+      {{ item.quantity === 0 ? 0 : item.quantity }} {{ translate("units") }}
     </ion-badge>
     <ion-note v-else-if="item.itemStatusId === 'INV_COUNT_COMPLETED'" color="success">
       {{ translate("accepted") }}


### PR DESCRIPTION

### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#377 

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
- Added a quantity check for `0` value in Inventory count.
- The item with a 0 inventory count should be saved correctly and should not appear as pending in the Assigned section.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->
Before - 
![Screenshot from 2024-07-19 18-42-37](https://github.com/user-attachments/assets/c1b46370-729e-45d5-b05d-5014d00e848d)

After - 
![image](https://github.com/user-attachments/assets/c7938ace-3209-45fe-86de-772ffd86b0df)


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I have read and followed [contribution rules](https://github.com/hotwax/inventory-count#contribution-guideline)
