### PR TITLE
Improved: logic to check for quantity being undefined when checking w…

### DIFF
--- a/src/views/AssignedDetail.vue
+++ b/src/views/AssignedDetail.vue
@@ -85,7 +85,7 @@
               <p>{{ translate("QoH") }}</p>
             </ion-label>
 
-            <template v-if="item.quantity">
+            <template v-if="item.quantity >=0 ">
               <ion-label>
                 {{ item.quantity }}
                 <p>{{ translate("counted") }}</p>
@@ -101,7 +101,7 @@
               <ion-label>{{ translate("count pending") }}</ion-label>
             </ion-chip>
 
-            <ion-chip outline v-if="item.quantity">
+            <ion-chip outline v-if="item.quantity >= 0">
               <ion-icon :icon="personCircleOutline"/>
               <ion-label>{{ getPartyName(item) }}</ion-label>
             </ion-chip>
@@ -323,7 +323,7 @@ function getVarianceInformation() {
 function getProgress() {
   const currentStats = cycleCountStats.value(currentCycleCount.value.countId) || {}
   const progress = ((currentStats.itemCounted || 0) / (currentStats.totalItems || 0)) * 100
-  return `${isNaN(progress) ? 0 : progress}% progress`
+  return `${isNaN(progress) ? 0 : progress.toFixed(2)}% progress`
 }
 
 async function updateCountStatus() {

--- a/src/views/PendingReviewDetail.vue
+++ b/src/views/PendingReviewDetail.vue
@@ -109,7 +109,7 @@
               </ion-label>
             </ion-item>
 
-            <ion-label v-if="item.quantity">
+            <ion-label v-if="item.quantity >= 0">
               {{ item.quantity }} / {{ item.qoh }}
               <p>{{ translate("counted / systemic") }}</p>
             </ion-label>
@@ -119,7 +119,7 @@
               <p>{{ translate("systemic") }}</p>
             </ion-label>
 
-            <ion-label v-if="item.quantity">
+            <ion-label v-if="item.quantity >= 0">
               {{ +(item.quantity) - +(item.qoh) }}
               <p>{{ getPartyName(item) }}</p>
             </ion-label>
@@ -135,7 +135,7 @@
               <ion-button :disabled="isItemCompletedOrRejected(item)" :fill="isItemReadyToAccept(item) && item.itemStatusId === 'INV_COUNT_CREATED' ? 'outline' : 'clear'" color="success" size="small" @click="acceptItem(item)">
                 <ion-icon slot="icon-only" :icon="thumbsUpOutline"></ion-icon>
               </ion-button>
-              <ion-button :disabled="isItemCompletedOrRejected(item)" :fill="!item.quantity && item.itemStatusId === 'INV_COUNT_CREATED' ? 'outline' : 'clear'" color="warning" size="small" class="ion-margin-horizontal" @click="recountItem(item)">
+              <ion-button :disabled="isItemCompletedOrRejected(item)" :fill="item.quantity === undefined && item.itemStatusId === 'INV_COUNT_CREATED' ? 'outline' : 'clear'" color="warning" size="small" class="ion-margin-horizontal" @click="recountItem(item)">
                 <ion-icon slot="icon-only" :icon="refreshOutline"></ion-icon>
               </ion-button>
               <ion-button :disabled="isItemCompletedOrRejected(item)" :fill="isItemReadyToReject(item) && item.itemStatusId === 'INV_COUNT_CREATED' ? 'outline' : 'clear'" color="danger" size="small" @click="updateItemStatus('INV_COUNT_REJECTED', item)">
@@ -348,11 +348,13 @@ function updateVarianceThreshold(event: any) {
 }
 
 function isItemReadyToAccept(item: any) {
-  return item.quantity ? Math.round(Math.abs(((item.quantity - (item.qoh || 0)) / (item.qoh || 0)) * 100)) <= varianceThreshold.value : false
+  // If the items qoh/quantity is not available then we will consider that the variance percentage is 100%, as we are unable to identify the % without qoh/quantity. Thus if qoh/quantity is not present for an item
+  // then we will suggest it for acceptance only when variance threshold is set to 100%
+  return item.quantity > 0 ? (item.qoh > 0 ? Math.round(Math.abs(((item.quantity - item.qoh) / item.qoh) * 100)) : 100) <= varianceThreshold.value : item.quantity === undefined ? false : 100 <= varianceThreshold.value
 }
 
 function isItemReadyToReject(item: any) {
-  return item.quantity ? Math.round(Math.abs(((item.quantity - (item.qoh || 0)) / (item.qoh || 0)) * 100)) > varianceThreshold.value : false
+  return item.quantity > 0 ? (item.qoh > 0 ? Math.round(Math.abs(((item.quantity - item.qoh) / item.qoh) * 100)) : 100) > varianceThreshold.value : item.quantity === undefined ? false : 100 > varianceThreshold.value
 }
 
 function isItemCompletedOrRejected(item: any) {


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#379 

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
Added check for quantity and qoh before calculating the variance threshold. If the quantity or qoh is missing on the item, then the item then the items will be marked as accepted only when the threshold is set to 100.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->
![image](https://github.com/user-attachments/assets/93fae79a-641e-45d4-b756-9a50a1c388aa)

![image](https://github.com/user-attachments/assets/0759b7fc-7fdd-4aa5-acec-ba6f44c7b3ef)


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I have read and followed [contribution rules](https://github.com/hotwax/inventory-count#contribution-guideline)
