### PR TITLE
Fixed: Items should be visible when the user switches to any tab and returns to the count section (#393)

### DIFF
--- a/src/views/CountDetail.vue
+++ b/src/views/CountDetail.vue
@@ -136,6 +136,8 @@ let filteredItems = ref([]);
 onIonViewDidEnter(async() => {  
   await fetchCycleCount();
   await fetchCycleCountItems();
+  selectedSegment.value = 'all';
+  queryString.value = '';
   updateFilteredItems();
   emitter.on("updateItemList", updateFilteredItems);
   await store.dispatch("product/currentProduct", itemsList.value[0])


### PR DESCRIPTION


### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#393 

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
- Items should be visible when the user switches to any tab and returns to the count section.
- Reset the segment to 'all' & search query when the view is entered



### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I have read and followed [contribution rules](https://github.com/hotwax/inventory-count#contribution-guideline)
