### PR TITLE
Improved: label for filters and removed check to disable filters when counts are not found(#398)

### DIFF
--- a/src/components/Filters.vue
+++ b/src/components/Filters.vue
@@ -13,7 +13,7 @@
         </ion-item-divider>
         <ion-item>
           <ion-icon slot="start" :icon="businessOutline"/>
-          <ion-select multiple interface="popover" :value="query.facilityIds" :selected-text="getSelectedValue()" :label="translate('Facility')" :placeholder="translate('Select facility')" @ionChange="updateQuery('facilityIds', $event.detail.value)">
+          <ion-select multiple interface="popover" :value="query.facilityIds" :selected-text="getSelectedValue()" :label="translate('Assigned to')" :placeholder="translate('Select facility')" @ionChange="updateQuery('facilityIds', $event.detail.value)">
             <ion-select-option v-for="facility in facilities" :key="facility.facilityId" :value="facility.facilityId">{{ facility.facilityName }}</ion-select-option>
           </ion-select>
         </ion-item>

--- a/src/views/Assigned.vue
+++ b/src/views/Assigned.vue
@@ -5,7 +5,7 @@
       <ion-toolbar>
         <ion-title>{{ translate("Assigned")}}</ion-title>
         <ion-buttons slot="end">
-          <ion-menu-button menu="filter" :disabled="!cycleCounts?.length">
+          <ion-menu-button menu="filter">
             <ion-icon :icon="filterOutline" />
           </ion-menu-button>
         </ion-buttons>

--- a/src/views/Draft.vue
+++ b/src/views/Draft.vue
@@ -6,7 +6,7 @@
         <ion-menu-button slot="start" menu="start"/>
         <ion-title>{{ translate("Drafts") }}</ion-title>
         <ion-buttons slot="end">
-          <ion-menu-button menu="draft-filter" :disabled="!cycleCounts?.length">
+          <ion-menu-button menu="draft-filter">
             <ion-icon :icon="filterOutline" />
           </ion-menu-button>
         </ion-buttons>

--- a/src/views/PendingReview.vue
+++ b/src/views/PendingReview.vue
@@ -5,7 +5,7 @@
       <ion-toolbar>
         <ion-title>{{ translate("Pending review")}}</ion-title>
         <ion-buttons slot="end">
-          <ion-menu-button menu="filter" :disabled="!cycleCounts?.length">
+          <ion-menu-button menu="filter">
             <ion-icon :icon="filterOutline" />
           </ion-menu-button>
         </ion-buttons>


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#398

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
Currently after applying the filter if the counts are not found then the filter becomes disabled. so removed the check to disable the feature always.
Updated the filter label to `Assigned to`

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I have read and followed [contribution rules](https://github.com/hotwax/inventory-count#contribution-guideline)
