### PR TITLE
Fixed: added bottom padding to prevent tab bar overlapping on the last count(#396)

### DIFF
--- a/src/views/Count.vue
+++ b/src/views/Count.vue
@@ -264,6 +264,9 @@ function getClosedDate(count) {
 </script> 
 
 <style scoped>
+section {
+  padding-bottom: 100px
+}
 
 ion-card {
   min-width: 400px;


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#396 

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
- Added bottom padding to the list section of the count that is preventing the overlapping of the tab bar on the last count.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->
![Screenshot from 2024-08-01 14-23-05](https://github.com/user-attachments/assets/ccdfb888-178e-434d-aaa0-e3296b8f78b9)


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I have read and followed [contribution rules](https://github.com/hotwax/inventory-count#contribution-guideline)
