### PR TITLE
FIxed: on saving the empty re-count a toast will show-up(#397)

### DIFF
--- a/src/views/ProductDetail.vue
+++ b/src/views/ProductDetail.vue
@@ -209,6 +209,11 @@
   }
 
   async function openRecountSaveAlert() {
+    if (!inputCount.value) {
+      showToast(translate("Enter a count before saving changes"));
+      return;
+    }
+    
     const alert = await alertController.create({
       header: translate("Save re-count"),
       message: translate("Saving recount will replace the existing count for item."),

--- a/src/views/ProductDetail.vue
+++ b/src/views/ProductDetail.vue
@@ -130,10 +130,10 @@
   const inputCount = ref('');
   const variance = ref(0);
 
-  // Clearning the local defined data variables to be cleared when the component is updated
+  // Update variance value when component is updated, ensuring it's prefilled with correct value when page loads.
   onUpdated(() => {
-    variance.value = 0
-  })
+    calculateVariance();
+  });
 
   function inputCountValidation(event: any) {
     if(/[`!@#$%^&*()_+\-=\\|,.<>?~e]/.test(event.key) && event.key !== 'Backspace') event.preventDefault();

--- a/src/views/ProductDetail.vue
+++ b/src/views/ProductDetail.vue
@@ -158,7 +158,7 @@
   }
 
   async function saveCount() {
-    if (!product.value || !inputCount.value) {
+    if (!inputCount.value) {
       showToast(translate("Enter a count before saving changes"))
       return;
     }

--- a/src/views/ProductDetail.vue
+++ b/src/views/ProductDetail.vue
@@ -136,8 +136,7 @@
   });
 
   function inputCountValidation(event: any) {
-  const newValue = event.target.value + event.key;
-    if(/^0\d+/.test(newValue) || /[`!@#$%^&*()_+\-=\\|,.<>?~e]/.test(event.key) && event.key !== 'Backspace') event.preventDefault();
+    if(/[`!@#$%^&*()_+\-=\\|,.<>?~e]/.test(event.key) && event.key !== 'Backspace') event.preventDefault();
   }
 
   async function calculateVariance() {

--- a/src/views/ProductDetail.vue
+++ b/src/views/ProductDetail.vue
@@ -136,7 +136,8 @@
   });
 
   function inputCountValidation(event: any) {
-    if(/[`!@#$%^&*()_+\-=\\|,.<>?~e]/.test(event.key) && event.key !== 'Backspace') event.preventDefault();
+  const newValue = event.target.value + event.key;
+    if(/^0\d+/.test(newValue) || /[`!@#$%^&*()_+\-=\\|,.<>?~e]/.test(event.key) && event.key !== 'Backspace') event.preventDefault();
   }
 
   async function calculateVariance() {

--- a/src/views/ProductDetail.vue
+++ b/src/views/ProductDetail.vue
@@ -132,7 +132,6 @@
 
   // Clearning the local defined data variables to be cleared when the component is updated
   onUpdated(() => {
-    inputCount.value = ""
     variance.value = 0
   })
 
@@ -178,6 +177,7 @@
         product.value.countedByUserLoginId = userProfile.value.username
         await store.dispatch('product/currentProduct', product.value);
         inputCount.value = ''; 
+        product.value.isRecounting = false;
       } else {
         throw resp.data;
       }
@@ -200,7 +200,7 @@
       {
         text: translate('Re-count'),
         handler: () => {
-          inputCount.value = ''; 
+          inputCount.value = product.value.quantity; 
           product.value.isRecounting = true;
         }
       }]
@@ -220,7 +220,6 @@
         text: translate('Save Re-count'),
         handler: async () => {
           await saveCount(); 
-          product.value.isRecounting = false;
         }
       }]
     });


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#397 

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
- Changed the logic to show the toast message "Enter a count before saving changes" when the user attempts to save an empty re-count.
- Additionally, on the re-count screen, the pre-filled quantity value will be shown so that the user knows the previous count of the item and can edit it if needed.

### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I have read and followed [contribution rules](https://github.com/hotwax/inventory-count#contribution-guideline)
