### PR TITLE
Improved: added checks on showing variance & re-count button on Product detail section(#380)

### DIFF
--- a/src/views/ProductDetail.vue
+++ b/src/views/ProductDetail.vue
@@ -25,7 +25,7 @@
               {{ translate("Current on hand") }}
               <ion-label slot="end">{{ product.qoh }}</ion-label>
             </ion-item>
-            <ion-item>
+            <ion-item v-if="product.itemStatusId !== 'INV_COUNT_REJECTED'">
               {{ translate("Variance") }}
               <ion-label slot="end">{{ getVariance(product) }}</ion-label>
             </ion-item>
@@ -76,7 +76,7 @@
                 {{ translate("Current on hand") }}
                 <ion-label slot="end">{{ product.qoh }}</ion-label>
               </ion-item>
-              <ion-item>
+              <ion-item v-if="product.itemStatusId !== 'INV_COUNT_REJECTED'">
                 {{ translate("Variance") }}
                 <ion-label slot="end">{{ getVariance(product) }}</ion-label>
               </ion-item>
@@ -100,7 +100,7 @@
                 <ion-label slot="end">{{ variance }}</ion-label>
               </ion-item>
             </template>
-            <ion-button class="ion-margin" fill="outline" expand="block" @click="saveCount()">
+            <ion-button v-if="!['INV_COUNT_REJECTED', 'INV_COUNT_COMPLETED'].includes(product.itemStatusId)" class="ion-margin" fill="outline" expand="block" @click="saveCount()">
               {{ translate("Save count") }}
             </ion-button>
           </ion-list>

--- a/src/views/ProductDetail.vue
+++ b/src/views/ProductDetail.vue
@@ -81,7 +81,7 @@
                 <ion-label slot="end">{{ getVariance(product) }}</ion-label>
               </ion-item>
             </template>
-            <ion-button class="ion-margin" fill="outline" expand="block" @click="openRecountAlert()">
+            <ion-button v-if="!['INV_COUNT_REJECTED', 'INV_COUNT_COMPLETED'].includes(product.itemStatusId)" class="ion-margin" fill="outline" expand="block" @click="openRecountAlert()">
               {{ translate("Re-count") }}
             </ion-button>
           </ion-list>


### PR DESCRIPTION

### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#380 

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
- So we removed the re-count button when the item status is INV_COUNT_REJECTED or INV_COUNT_COMPLETED.
- Also removed the variance for items in rejected status if the cycle count is in created / assigned status.
- If the item in the cycle count is already counted and can be recounted, we avoid showing the variance of rejected items.

### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I have read and followed [contribution rules](https://github.com/hotwax/inventory-count#contribution-guideline)
