### PR TITLE
Improved: code to have empty count name while renaming the count

### DIFF
--- a/src/views/AssignedDetail.vue
+++ b/src/views/AssignedDetail.vue
@@ -248,10 +248,15 @@ async function editCountName() {
 }
 
 async function updateCountName() {
-  if(countName.value?.trim() && countName.value.trim() !== currentCycleCount.value.countName.trim()) {
+  if(!countName.value?.trim()) {
+    showToast(translate("Enter a valid cycle count name"))
+    return;
+  }
+
+  if(countName.value.trim() !== currentCycleCount.value.countName?.trim()) {
     const inventoryCountImportId = await CountService.updateCycleCount({ inventoryCountImportId: currentCycleCount.value.countId, countImportName: countName.value.trim() })
     if(inventoryCountImportId) {
-      currentCycleCount.value.countName = countName.value
+      currentCycleCount.value.countName = countName.value.trim()
     } else {
       countName.value = currentCycleCount.value.countName.trim()
     }

--- a/src/views/DraftDetail.vue
+++ b/src/views/DraftDetail.vue
@@ -352,10 +352,15 @@ async function editCountName() {
 }
 
 async function updateCountName() {
-  if(countName.value?.trim() && countName.value.trim() !== currentCycleCount.value.countName.trim()) {
+  if(!countName.value?.trim()) {
+    showToast(translate("Enter a valid cycle count name"))
+    return;
+  }
+
+  if(countName.value.trim() !== currentCycleCount.value.countName.trim()) {
     const inventoryCountImportId = await CountService.updateCycleCount({ inventoryCountImportId: currentCycleCount.value.countId, countImportName: countName.value.trim() })
     if(inventoryCountImportId) {
-      currentCycleCount.value.countName = countName.value
+      currentCycleCount.value.countName = countName.value.trim()
     } else {
       countName.value = currentCycleCount.value.countName.trim()
     }

--- a/src/views/PendingReviewDetail.vue
+++ b/src/views/PendingReviewDetail.vue
@@ -336,10 +336,15 @@ async function editCountName() {
 }
 
 async function updateCountName() {
-  if(countName.value?.trim() && countName.value.trim() !== currentCycleCount.value.countName.trim()) {
+  if(!countName.value?.trim()) {
+    showToast(translate("Enter a valid cycle count name"))
+    return;
+  }
+
+  if(countName.value.trim() !== currentCycleCount.value.countName.trim()) {
     const inventoryCountImportId = await CountService.updateCycleCount({ inventoryCountImportId: currentCycleCount.value.countId, countImportName: countName.value.trim() })
     if(inventoryCountImportId) {
-      currentCycleCount.value.countName = countName.value
+      currentCycleCount.value.countName = countName.value.trim()
     } else {
       countName.value = currentCycleCount.value.countName.trim()
     }


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
When renaming a count, user can save the count name even when the name is empty this added check to display a toast when saving an empty count name

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I have read and followed [contribution rules](https://github.com/hotwax/inventory-count#contribution-guideline)
