### PR TITLE
Fixed: Corrected default url for the back button on bulk upload page.

### DIFF
--- a/src/views/BulkUpload.vue
+++ b/src/views/BulkUpload.vue
@@ -2,7 +2,7 @@
   <ion-page>
     <ion-header :translucent="true">
       <ion-toolbar>
-        <ion-back-button default-href="/tabs/count" slot="start"></ion-back-button>
+        <ion-back-button slot="start" default-href="/draft" />
         <ion-title>{{ translate("Draft bulk") }}</ion-title>
       </ion-toolbar>
     </ion-header>


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#

### Short Description and Why It's Useful
Fixed: Corrected default url for the back button on bulk upload page.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [ ] I have read and followed [contribution rules](https://github.com/hotwax/inventory-count#contribution-guideline)
