### PR TITLE
Improved: resetting the fieldMapping after every file upload(#457)

### DIFF
--- a/src/views/BulkUpload.vue
+++ b/src/views/BulkUpload.vue
@@ -216,7 +216,8 @@ async function parse(event) {
       content.value = await parseCsv(uploadedFile.value);
       fileColumns.value = Object.keys(content.value[0]);
       showToast(translate("File uploaded successfully."));
-      fileUploaded.value =!fileUploaded.value; 
+      fileUploaded.value =!fileUploaded.value;
+      selectedMappingId.value = null;
       resetFieldMapping();
     } else {
       showToast(translate("No new file upload. Please try again."));

--- a/src/views/BulkUpload.vue
+++ b/src/views/BulkUpload.vue
@@ -139,19 +139,19 @@ onIonViewDidEnter(async() => {
   content.value = []
   fileName.value = null
   
-  fieldMapping.value = Object.keys(fields).reduce((fieldMapping, field) => {
-    fieldMapping[field] = ""
-    return fieldMapping;
-  }, {})
+  resetFieldMapping();
   file.value.value = null;
   await store.dispatch('user/getFieldMappings')
   await store.dispatch('count/fetchCycleCountImportSystemMessages')
 })
-function resetDefaults() {
+function resetFieldMapping() {
   fieldMapping.value = Object.keys(fields).reduce((fieldMapping, field) => {
     fieldMapping[field] = ""
     return fieldMapping;
   }, {})
+}
+function resetDefaults() {
+  resetFieldMapping();
   uploadedFile.value = {}
   content.value = []
   fileName.value = null
@@ -217,6 +217,7 @@ async function parse(event) {
       fileColumns.value = Object.keys(content.value[0]);
       showToast(translate("File uploaded successfully."));
       fileUploaded.value =!fileUploaded.value; 
+      resetFieldMapping();
     } else {
       showToast(translate("No new file upload. Please try again."));
     }

--- a/src/views/BulkUpload.vue
+++ b/src/views/BulkUpload.vue
@@ -216,7 +216,7 @@ async function parse(event) {
       content.value = await parseCsv(uploadedFile.value);
       fileColumns.value = Object.keys(content.value[0]);
       showToast(translate("File uploaded successfully."));
-      fileUploaded.value =!fileUploaded.value;
+      fileUploaded.value = !fileUploaded.value;
       selectedMappingId.value = null;
       resetFieldMapping();
     } else {


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#457 

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
- Added code to reset the field mapping.
- After uploading a new file with different columns, the previously mapped fields are reset, and the modal props are also updated, which solves the 4th case.



### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I have read and followed [contribution rules](https://github.com/hotwax/inventory-count#contribution-guideline)
