### PR TITLE
Improved: added backdrop property which prevent triggering of any action(#474)

### DIFF
--- a/src/store/modules/count/actions.ts
+++ b/src/store/modules/count/actions.ts
@@ -12,7 +12,7 @@ import { DateTime } from "luxon"
 
 const actions: ActionTree<CountState, RootState> = {
   async fetchCycleCounts({ commit, dispatch, state }, payload) {
-    emitter.emit("presentLoader", { message: "Fetching cycle counts..." })
+    emitter.emit("presentLoader", { message: "Fetching cycle counts...", backdropDismiss: false })
     let counts: Array<any> = [], total = 0;
 
     const params = {


### PR DESCRIPTION

### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#474 

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
- Added `backDropDismiss` property as false, which prevent the triggering of any action after and no count record should open unintentionally after the results are fetched.


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I have read and followed [contribution rules](https://github.com/hotwax/inventory-count#contribution-guideline)
