### PR TITLE
Fixed - count name issue (#440)

### DIFF
--- a/src/views/Count.vue
+++ b/src/views/Count.vue
@@ -2,7 +2,7 @@
   <ion-page>
     <ion-header>
       <ion-toolbar>
-        <ion-title slot="start">{{ translate("Count name") }}</ion-title>
+        <ion-title slot="start">{{ currentFacility?.facilityName || translate("Count name") }}</ion-title>
         <ion-segment :value="selectedSegment" @ionChange="segmentChanged($event.detail.value)">
           <ion-segment-button value="assigned" @click="selectedSegment = 'assigned'">
             <ion-label>{{ translate("Assigned") }}</ion-label>


### PR DESCRIPTION
### Related Issues
issue no #440 
#

### Short Description and Why It's Useful
<!-- The list page was updated to display the selected facility name instead of the static "Count Name," while keeping the count name on the details page unchanged.>


### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I have read and followed [contribution rules](https://github.com/hotwax/inventory-count#contribution-guideline)
