### PR TITLE
Fixed - toast message when user cancels CSV upload operation on Bulk (#479)

### DIFF
--- a/src/views/BulkUpload.vue
+++ b/src/views/BulkUpload.vue
@@ -211,6 +211,22 @@ async function parse(event) {
   const file = event.target.files[0];
   try {
     if (file) {
+      const fileExtension = file.name.split('.')[1];      
+      // Added n file extension check
+      if(fileExtension !== 'csv'){
+        console.log("Not a csv file.")
+        showToast(translate("Please upload a csv file only."));
+        return;
+      }
+      
+      resetDefaults();
+      console.log(uploadedFile.value.size);
+      if(uploadedFile.value != {}){
+        console.log("There is already a file");
+        // return;
+      }else{
+        console.log("There is no file");
+      }
       uploadedFile.value = file;
       fileName.value = file.name
       content.value = await parseCsv(uploadedFile.value);


### PR DESCRIPTION
…Upload page #479

### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#479

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
created an extension check on the uploaded files, and if the user cancels the upload of a file, then the state of the upload is reset to defaults, which does not display the previous unnecessary message


<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I have read and followed [contribution rules](https://github.com/hotwax/inventory-count#contribution-guideline)
