### PR TITLE
Fixed: both the item change buttons becomes active after changing tab(#442)

### DIFF
--- a/src/views/CountDetail.vue
+++ b/src/views/CountDetail.vue
@@ -345,7 +345,9 @@ function updateFilteredItems() {
     });
   }
   if (filteredItems.value.length > 0) {
-    const updatedProduct = Object.keys(product.value)?.length ? product.value : filteredItems.value[0]
+    // As we want to get the index of the product, if we directly store the product in the updatedProduct variable it does not return the index
+    // as both the object becomes different because of the reference, so if we have a product, then first finding it in the filtered list to have a common reference and then getting the index
+    const updatedProduct = Object.keys(product.value)?.length ? filteredItems.value.find((item) => item.productId === product.value.productId && item.importItemSeqId === product.value.importItemSeqId) : filteredItems.value[0]
     store.dispatch("product/currentProduct", updatedProduct);
     updateNavigationState(filteredItems.value.indexOf(updatedProduct));
   } else {


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#442 

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
As we are using indexOf method for finding the product index, but if we already have a current product set, then in that case the product from state is used for finding the index from the filteredItems list, but as the object do not have a common reference, so in this case it always return -1, resulting in buttons being in wrong state.
Improved code to find the selected current product first in the filtered items list and then finding its index, so that it has a common reference.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->
Before:
Both the buttons are active, even when its the first product.

![image](https://github.com/user-attachments/assets/22ff5302-9092-42b5-a657-bcc33b5a8890)


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I have read and followed [contribution rules](https://github.com/hotwax/inventory-count#contribution-guideline)
