### PR TITLE
Fixed: wrong updation of cycle count items list on saving recount (#494)

### DIFF
--- a/src/views/CountDetail.vue
+++ b/src/views/CountDetail.vue
@@ -534,7 +534,7 @@ async function saveCount(currentProduct) {
       currentProduct.countedByUserLoginId = userProfile.value.username
       currentProduct.isRecounting = false;
       inputCount.value = ''; 
-      const items = JSON.parse(JSON.stringify(itemsList.value))
+      const items = JSON.parse(JSON.stringify(cycleCountItems.value.itemList))
       items.map((item) => {
         if(item.importItemSeqId === currentProduct.importItemSeqId) {
           item.quantity = currentProduct.quantity


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#494

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
Fixed items list not updating properly on saving recount.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I have read and followed [contribution rules](https://github.com/hotwax/inventory-count#contribution-guideline)
