### PR TITLE
Improved: UI for the recount to show previous count and updated validation to allow user save 0 as count (#494)

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -152,6 +152,7 @@
   "Make sure you've reviewed the products and their counts before uploading them for review": "Make sure you've reviewed the products and their counts before uploading them for review",
   "Map all required fields": "Map all required fields",
   "Mapping name": "Mapping name",
+  "New Count": "New Count",
   "New mapping": "New mapping",
   "No cycle counts found": "No cycle counts found",
   "No items found": "No items found",

--- a/src/views/CountDetail.vue
+++ b/src/views/CountDetail.vue
@@ -114,7 +114,12 @@
               <template v-else>
                 <ion-list v-if="product.isRecounting">
                   <ion-item>
-                    <ion-input :label="translate('Count')" :disabled="productStoreSettings['forceScan']" :placeholder="translate('submit physical count')" name="value" v-model="inputCount" id="value" type="number" min="0" required @ionInput="hasUnsavedChanges=true" @keydown="inputCountValidation"/>
+                    <ion-input :label="translate('New Count')" :disabled="productStoreSettings['forceScan']" :placeholder="translate('submit physical count')" name="value" v-model="inputCount" id="value" type="number" min="0" required @ionInput="hasUnsavedChanges=true" @keydown="inputCountValidation"/>
+                  </ion-item>
+
+                  <ion-item>
+                    {{ translate("Current count") }}
+                    <ion-label slot="end">{{ product.quantity }}</ion-label>
                   </ion-item>
 
                   <template v-if="productStoreSettings['showQoh']">
@@ -515,7 +520,7 @@ function getVariance(item , isRecounting) {
 }
 
 async function saveCount(currentProduct) {
-  if (!inputCount.value) {
+  if (!inputCount.value && inputCount.value !== 0) {
     showToast(translate("Enter a count before saving changes"))
     return;
   }
@@ -575,7 +580,7 @@ async function openRecountAlert() {
 }
 
 async function openRecountSaveAlert() {
-  if (!inputCount.value) {
+  if (!inputCount.value && inputCount.value !== 0) {
     showToast(translate("Enter a count before saving changes"));
     return;
   }


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#494

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
- Improved ui for the recount detail page to show current count along with new count.
- Updated validation to allow user save 0 as count.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->
Before
![Screenshot from 2024-11-12 11-45-52](https://github.com/user-attachments/assets/bd43f549-d0b5-462c-94de-056e0be53440)


After
![Screenshot from 2024-11-12 11-37-56](https://github.com/user-attachments/assets/0d578ae8-dabb-4693-a570-e5bd0ab287b7)


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I have read and followed [contribution rules](https://github.com/hotwax/inventory-count#contribution-guideline)
