### PR TITLE
Improved: fetching dynamic good identification from store permissions page and showing 'not counted' for rejected item without quantity (#494)

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -289,7 +289,7 @@
   "Update time zone": "Update time zone",
   "Upload": "Upload",
   "Upload inventory count": "Upload inventory count",
-  "units": "units",
+  "units": "{count} units",
   "Username": "Username",
   "Variance": "Variance",
   "variance": "variance",

--- a/src/views/CountDetail.vue
+++ b/src/views/CountDetail.vue
@@ -428,7 +428,7 @@ async function scanProduct() {
       hasUnsavedChanges.value = true;
       inputCount.value++
     } else if(selectedItem.quantity >= 0 && selectedItem.itemStatusId !== "INV_COUNT_REJECTED" && selectedItem.itemStatusId !== "INV_COUNT_COMPLETED") {
-      this.openRecountAlert()
+      openRecountAlert()
     }
   }
   queryString.value = ""

--- a/src/views/CountDetail.vue
+++ b/src/views/CountDetail.vue
@@ -423,6 +423,7 @@ async function scanProduct() {
         element.scrollIntoView({ behavior: 'smooth' });
       }
     }, 0);
+    if(!selectedItem.quantity && selectedItem.quantity !== 0) inputCount.value = ""
   } else if(selectedItem.itemStatusId === "INV_COUNT_CREATED") {
     if((!selectedItem.quantity && selectedItem.quantity !== 0) || product.value.isRecounting) {
       hasUnsavedChanges.value = true;

--- a/src/views/CountDetail.vue
+++ b/src/views/CountDetail.vue
@@ -423,7 +423,7 @@ async function scanProduct() {
         element.scrollIntoView({ behavior: 'smooth' });
       }
     }, 0);
-    if(!selectedItem.quantity && selectedItem.quantity !== 0) inputCount.value = ""
+    inputCount.value = ""
   } else if(selectedItem.itemStatusId === "INV_COUNT_CREATED") {
     if((!selectedItem.quantity && selectedItem.quantity !== 0) || product.value.isRecounting) {
       hasUnsavedChanges.value = true;

--- a/src/views/ProductItemList.vue
+++ b/src/views/ProductItemList.vue
@@ -9,13 +9,13 @@
       <p>{{ getProductIdentificationValue(productStoreSettings["productIdentificationPref"].secondaryId, getProduct(item.productId)) }}</p>
     </ion-label>
     <ion-badge slot="end" color="danger" v-if="item.itemStatusId === 'INV_COUNT_REJECTED'">
-      {{ item.quantity === 0 ? 0 : item.quantity }} {{ translate("units") }}
+      {{ (!item.quantity && item.quantity !== 0) ? translate("not counted") : translate("units", { count: item.quantity }) }}
     </ion-badge>
     <ion-note v-else-if="item.itemStatusId === 'INV_COUNT_COMPLETED'" color="success">
       {{ translate("accepted") }}
     </ion-note>
     <ion-badge slot="end" v-else-if="item.quantity >= 0 && item.statusId === 'INV_COUNT_ASSIGNED'">
-      {{ item.quantity }} {{ translate("units") }}
+      {{ translate("units", { count: item.quantity }) }}
     </ion-badge>
     <ion-note v-else-if="item.quantity === undefined || item.quantity === null && item.statusId === 'INV_COUNT_ASSIGNED'">
       {{ translate("pending") }}

--- a/src/views/StorePermissions.vue
+++ b/src/views/StorePermissions.vue
@@ -73,6 +73,7 @@ const productIdentifications = computed(() => store.getters["user/getGoodIdentif
 
 onIonViewWillEnter(async () => {
   await store.dispatch("user/getProductStoreSetting")
+  await store.dispatch("user/fetchGoodIdentificationTypes")
 })
 
 function updateProductStoreSetting(event: any, key: string) {


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#494

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
-  fetching dynamic good identification from store permissions page.
-  showing 'not counted' for rejected item without quantity
- Reseting inputCount with "" on bringing new product to veiw.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I have read and followed [contribution rules](https://github.com/hotwax/inventory-count#contribution-guideline)
