### PR TITLE
Fixed: issue where re-clicking 'Draft' blocked access to 'Draft Bulk' via the FAB button(#446)

### DIFF
--- a/src/views/Draft.vue
+++ b/src/views/Draft.vue
@@ -35,7 +35,7 @@
           <ion-fab-button @click="createCycleCount">
             <ion-icon :icon="documentOutline" />
           </ion-fab-button>
-          <ion-fab-button @click="router.push('/bulkUpload')">
+          <ion-fab-button @click="router.replace('/bulkUpload')">
             <ion-icon :icon="documentsOutline" />
           </ion-fab-button>
         </ion-fab-list>


### PR DESCRIPTION

### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#446 

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
-  Resolved an issue where, after clicking 'Drafts' while the page was already open, the user couldn't access the 'Draft Bulk' page through the FAB button, even though the route was changing.

### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I have read and followed [contribution rules](https://github.com/hotwax/inventory-count#contribution-guideline)
