### PR TITLE
Fixed: For unmatched saved mappings where the required field is empty the user will not be able to upload the file (#533)

### DIFF
--- a/src/views/BulkUpload.vue
+++ b/src/views/BulkUpload.vue
@@ -58,7 +58,7 @@
           </ion-item>
         </ion-list>
 
-        <ion-button :disabled="!content.length" color="medium" @click="save" expand="block">
+        <ion-button :disabled="!content.length || isUploadDisabled" color="medium" @click="save" expand="block">
           {{ translate("Upload") }}
           <ion-icon slot="end" :icon="cloudUploadOutline" />
         </ion-button>
@@ -130,6 +130,7 @@ let fieldMapping = ref({})
 let fileColumns = ref([])
 let selectedMappingId = ref(null)
 const fileUploaded = ref(false);
+const isUploadDisabled = ref(true);
 const fields = process.env["VUE_APP_MAPPING_INVCOUNT"] ? JSON.parse(process.env["VUE_APP_MAPPING_INVCOUNT"]) : {}
 
 
@@ -288,8 +289,12 @@ function mapFields(mapping, mappingId) {
   const missingFields = Object.values(fieldMappingData.value).filter(field => {
     if(!csvFields.includes(field)) return field;
   });
-
-  if(missingFields.length) showToast(translate("Some of the mapping fields are missing in the CSV: ", { missingFields: missingFields.join(", ") }))
+  if(missingFields.length) {
+    isUploadDisabled.value = true
+    showToast(translate("Some of the mapping fields are missing in the CSV: ", { missingFields: missingFields.join(", ") }))
+  } else {
+    isUploadDisabled.value = false;
+  }
 
   Object.keys(fieldMappingData).map((key) => {
     if(!csvFields.includes(fieldMappingData.value[key])){

--- a/src/views/BulkUpload.vue
+++ b/src/views/BulkUpload.vue
@@ -58,7 +58,7 @@
           </ion-item>
         </ion-list>
 
-        <ion-button :disabled="!content.length || isUploadDisabled" color="medium" @click="save" expand="block">
+        <ion-button :disabled="!content.length" color="medium" @click="save" expand="block">
           {{ translate("Upload") }}
           <ion-icon slot="end" :icon="cloudUploadOutline" />
         </ion-button>
@@ -130,7 +130,6 @@ let fieldMapping = ref({})
 let fileColumns = ref([])
 let selectedMappingId = ref(null)
 const fileUploaded = ref(false);
-const isUploadDisabled = ref(true);
 const fields = process.env["VUE_APP_MAPPING_INVCOUNT"] ? JSON.parse(process.env["VUE_APP_MAPPING_INVCOUNT"]) : {}
 
 
@@ -289,14 +288,9 @@ function mapFields(mapping, mappingId) {
   const missingFields = Object.values(fieldMappingData.value).filter(field => {
     if(!csvFields.includes(field)) return field;
   });
-  if(missingFields.length) {
-    isUploadDisabled.value = true
-    showToast(translate("Some of the mapping fields are missing in the CSV: ", { missingFields: missingFields.join(", ") }))
-  } else {
-    isUploadDisabled.value = false;
-  }
+  if(missingFields.length) showToast(translate("Some of the mapping fields are missing in the CSV: ", { missingFields: missingFields.join(", ") }))
 
-  Object.keys(fieldMappingData).map((key) => {
+  Object.keys(fieldMappingData.value).map((key) => {
     if(!csvFields.includes(fieldMappingData.value[key])){
       fieldMappingData.value[key] = "";
     }


### PR DESCRIPTION

### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#533 

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
- Added a check to keep the upload button disabled if the saved mapping does not align correctly with the CSV column fields.

### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I have read and followed [contribution rules](https://github.com/hotwax/inventory-count#contribution-guideline)
