### PR TITLE
Fixed: Users not associated with any facility will not be able to log in to the app (#529)

### DIFF
--- a/src/store/modules/user/actions.ts
+++ b/src/store/modules/user/actions.ts
@@ -182,6 +182,7 @@ const actions: ActionTree<UserState, RootState> = {
       }
     } catch(err) {
       logger.error("Failed to fetch facilities")
+      throw err
     }
 
     // Updating current facility with a default first facility when fetching facilities on login


### PR DESCRIPTION

### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#529 

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
- Added this change to re-throw the error after logging it because it ensures proper error handling by the calling code.
- Now, a user who does not have the "COMMON_ADMIN" permission and is not associated with any facility will not be able to log in to the application.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->
![image](https://github.com/user-attachments/assets/1c104c48-3ee4-4cfc-a8ea-eaaa687b6dcc)


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I have read and followed [contribution rules](https://github.com/hotwax/inventory-count#contribution-guideline)
