### PR TITLE
Fixed: ref getting assigned to previous item var (#528)

### DIFF
--- a/src/views/HardCountDetail.vue
+++ b/src/views/HardCountDetail.vue
@@ -511,7 +511,7 @@ const onScroll = (event: any) => {
           if(inputCount.value) saveCount(previousItem, true);
         }
 
-        previousItem = currentProduct  // Update the previousItem variable with the current item
+        previousItem = currentProduct.value  // Update the previousItem variable with the current item
         if(product) {
           store.dispatch("product/currentProduct", product);
         }


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#528

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
Assigning the value of currentProduct instead of it's ref for proper handling.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I have read and followed [contribution rules](https://github.com/hotwax/inventory-count#contribution-guideline)
