### PR TITLE
Improved: added logic to save count of item already counted after product fetching (#528)

### DIFF
--- a/src/views/CountDetail.vue
+++ b/src/views/CountDetail.vue
@@ -295,8 +295,7 @@ const barcodeInput = ref();
 let isScanningInProgress = ref(false);
 
 onIonViewDidEnter(async() => {  
-  await fetchCycleCount();
-  await fetchCycleCountItems();
+  await Promise.allSettled([await fetchCycleCount(), store.dispatch("count/fetchCycleCountItems", { inventoryCountImportId : props?.id })])
   selectedSegment.value = 'all';
   queryString.value = '';
   previousItem = itemsList.value[0]
@@ -346,10 +345,6 @@ onBeforeRouteLeave(async (to) => {
 
 function inputCountValidation(event) {
   if(/[`!@#$%^&*()_+\-=\\|,.<>?~e]/.test(event.key) && event.key !== 'Backspace') event.preventDefault();
-}
-
-async function fetchCycleCountItems() {
-  await store.dispatch("count/fetchCycleCountItems", { inventoryCountImportId : props?.id }); 
 }
 
 async function fetchCycleCount() {
@@ -463,7 +458,6 @@ const onScroll = (event) => {
         previousItem = currentProduct  // Update the previousItem variable with the current item
 
         if (currentProduct) {
-          const currentIndex = itemsList.value?.indexOf(currentProduct);
           store.dispatch("product/currentProduct", currentProduct);
           product.value.isRecounting = false;
         }

--- a/src/views/CountDetail.vue
+++ b/src/views/CountDetail.vue
@@ -88,11 +88,11 @@
                   <ion-label>{{ `${currentItemIndex + 1}/${itemsList.length}` }}</ion-label>
                 </ion-item>
 
-                <ion-button @click="changeProduct('previous')" :disabled="isFirstItem" fill="outline" shape="round" color="medium" class="ion-no-padding">
+                <ion-button @click="changeProduct('previous')" :disabled="currentItemIndex === 0" fill="outline" shape="round" color="medium" class="ion-no-padding">
                   <ion-icon slot="icon-only" :icon="chevronUpOutline"></ion-icon>
                 </ion-button>
 
-                <ion-button @click="changeProduct('next')" :disabled="isLastItem" fill="outline" shape="round" color="medium" class="ion-no-padding">
+                <ion-button @click="changeProduct('next')" :disabled="currentItemIndex = itemsList.length - 1" fill="outline" shape="round" color="medium" class="ion-no-padding">
                   <ion-icon slot="icon-only" :icon="chevronDownOutline"></ion-icon>
                 </ion-button>
               </ion-item>
@@ -288,8 +288,6 @@ let cycleCount = ref([]);
 const queryString = ref('');
 
 const inputCount = ref('');
-const isFirstItem = ref(true);
-const isLastItem = ref(false);
 const isScrolling = ref(false);
 let previousItem = {};
 let hasUnsavedChanges = ref(false);
@@ -303,7 +301,6 @@ onIonViewDidEnter(async() => {
   queryString.value = '';
   previousItem = itemsList.value[0]
   await store.dispatch("product/currentProduct", itemsList.value[0])
-  updateNavigationState(0);
   barcodeInput.value?.$el?.setFocus();
 })  
 
@@ -439,15 +436,11 @@ function updateFilteredItems() {
     const updatedProduct = Object.keys(product.value)?.length ? itemsList.value.find((item) => item.productId === product.value.productId && item.importItemSeqId === product.value.importItemSeqId) : itemsList.value[0]
     if (updatedProduct) {
       store.dispatch("product/currentProduct", updatedProduct);
-      updateNavigationState(itemsList.value.indexOf(updatedProduct));
     } else {
       store.dispatch("product/currentProduct", itemsList.value[0]);
-      updateNavigationState(0);
     }
   } else {
     store.dispatch("product/currentProduct", {});
-    isFirstItem.value = true
-    isLastItem.value = false
   }
 }
 
@@ -472,7 +465,6 @@ const onScroll = (event) => {
         if (currentProduct) {
           const currentIndex = itemsList.value?.indexOf(currentProduct);
           store.dispatch("product/currentProduct", currentProduct);
-          updateNavigationState(currentIndex);
           product.value.isRecounting = false;
         }
       }
@@ -485,12 +477,6 @@ const onScroll = (event) => {
   products.forEach((product) => {
     observer.observe(product);
   });
-};
-
-// Add this function to update the navigation state
-const updateNavigationState = (currentIndex) => {
-  isFirstItem.value = currentIndex === 0;
-  isLastItem.value = currentIndex === itemsList.value.length - 1;
 };
 
 async function changeProduct(direction) {
@@ -506,7 +492,6 @@ async function changeProduct(direction) {
     if (productEl) productEl.scrollIntoView({ behavior: 'smooth' });
     await new Promise(resolve => setTimeout(resolve, 500));
     await store.dispatch("product/currentProduct", product);
-    updateNavigationState(index);
   }
   isScrolling.value = false;
 }

--- a/src/views/CountDetail.vue
+++ b/src/views/CountDetail.vue
@@ -92,7 +92,7 @@
                   <ion-icon slot="icon-only" :icon="chevronUpOutline"></ion-icon>
                 </ion-button>
 
-                <ion-button @click="changeProduct('next')" :disabled="currentItemIndex = itemsList.length - 1" fill="outline" shape="round" color="medium" class="ion-no-padding">
+                <ion-button @click="changeProduct('next')" :disabled="currentItemIndex === itemsList.length - 1" fill="outline" shape="round" color="medium" class="ion-no-padding">
                   <ion-icon slot="icon-only" :icon="chevronDownOutline"></ion-icon>
                 </ion-button>
               </ion-item>

--- a/src/views/HardCountDetail.vue
+++ b/src/views/HardCountDetail.vue
@@ -478,8 +478,8 @@ async function updateCurrentItemInList(importItemSeqId: any, product: any, scann
       } else {
         item["isMatchNotFound"] = true
       }
+      item["isMatching"] = false;
       if(prevItem && Object.keys(prevItem)?.length && !hasErrorSavingCount) delete item["scannedCount"]
-      updatedProduct["isMatching"] = false;
     }
   })
 

--- a/src/views/HardCountDetail.vue
+++ b/src/views/HardCountDetail.vue
@@ -641,7 +641,7 @@ function getVariance(item: any , isRecounting: boolean) {
 }
 
 function hasUnsavedChanges() {
-  return inputCount.value >= 0 || cycleCountItems.value.itemList.find((item: any) => item.scannedCount && !item.isMatchNotFound);
+  return (inputCount.value && inputCount.value >= 0) || cycleCountItems.value.itemList.find((item: any) => item.scannedCount && !item.isMatchNotFound);
 }
 
 function isItemAlreadyAdded(product: any) {

--- a/src/views/HardCountDetail.vue
+++ b/src/views/HardCountDetail.vue
@@ -106,7 +106,7 @@
 
                 <ion-radio-group v-model="selectedCountUpdateType">
                   <ion-item>
-                    <ion-radio justify="start" label-placement="end" value="new">
+                    <ion-radio justify="start" label-placement="end" value="add">
                       <ion-label>
                         {{ translate("Add to existing count") }}
                       </ion-label>
@@ -234,7 +234,7 @@ const selectedSegment = ref("all");
 let previousItem = {} as any;
 const barcodeInputRef = ref();
 const inputCount = ref("") as any;
-const selectedCountUpdateType = ref("new");
+const selectedCountUpdateType = ref("add");
 const isScrolling = ref(false);
 let isScanningInProgress = ref(false);
 
@@ -563,7 +563,7 @@ async function saveCount(currentProduct: any, isScrollEvent = false) {
         const prevCount = currentProduct.scannedCount ? currentProduct.scannedCount : 0
 
         item.countedByUserLoginId = userProfile.value.username
-        if(selectedCountUpdateType.value === "new") item.scannedCount = inputCount.value
+        if(selectedCountUpdateType.value === "replace") item.scannedCount = inputCount.value
         else item.scannedCount = inputCount.value + prevCount
         currentItem = item;
       }

--- a/src/views/HardCountDetail.vue
+++ b/src/views/HardCountDetail.vue
@@ -440,7 +440,7 @@ async function updateCurrentItemInList(importItemSeqId: any, product: any, scann
   if(updatedProduct.scannedId === scannedValue) {
     if(importItemSeqId) {
       updatedProduct["importItemSeqId"] = importItemSeqId
-      updatedProduct["productId"] = product.oroductId
+      updatedProduct["productId"] = product.productId
       updatedProduct["isMatchNotFound"] = false
     } else {
       updatedProduct["isMatchNotFound"] = true


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->
#528

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
- Optimized code of CountDetail page.
- Logic to save count of previous selected item if product data came post changing.
- Fixed the handling for the behavior for the update cycle count behavior.


### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I have read and followed [contribution rules](https://github.com/hotwax/inventory-count#contribution-guideline)
