### PR TITLE
Fixed: match product modal not updating the item data in the state (#528)

### DIFF
--- a/src/components/MatchProductModal.vue
+++ b/src/components/MatchProductModal.vue
@@ -72,13 +72,16 @@ import { getProductIdentificationValue, hasError } from "@/utils"
 import Image from "@/components/Image.vue"
 import { ProductService } from "@/services/ProductService";
 import logger from "@/logger";
+
 const props = defineProps(["items"])
 const productStoreSettings = computed(() => store.getters["user/getProductStoreSettings"])
 const getProduct = computed(() => (id: any) => store.getters["product/getProduct"](id))
+
 const products = ref([]) as any;
 let queryString = ref('');
 const isSearching = ref(false);
 const selectedProductId = ref("") as Ref<string>;
+
 async function handleSearch() {
   if(!queryString.value.trim()) {
     isSearching.value = false; 
@@ -106,7 +109,9 @@ function closeModal(payload = {}) {
   modalController.dismiss({ dismissed: true, ...payload });
 }
 function save() {
-  closeModal({ selectedProduct: products.value.find((product: any) => product.productId === selectedProductId.value) })
+  const selectedProduct = products.value.find((product: any) => product.productId === selectedProductId.value)
+  store.dispatch("product/addProductToCached", selectedProduct);
+  closeModal({ selectedProduct })
 }
 function isProductAvailableInCycleCount(id: string) {
   return props.items.some((item: any) => item.productId === id && item.itemStatusId !== "INV_COUNT_REJECTED")

--- a/src/components/MatchProductModal.vue
+++ b/src/components/MatchProductModal.vue
@@ -106,7 +106,7 @@ function closeModal(payload = {}) {
   modalController.dismiss({ dismissed: true, ...payload });
 }
 function save() {
-  closeModal({ selectedProduct: products.value.find((product: any) => product.productId === selectedProductId) })
+  closeModal({ selectedProduct: products.value.find((product: any) => product.productId === selectedProductId.value) })
 }
 function isProductAvailableInCycleCount(id: string) {
   return props.items.some((item: any) => item.productId === id && item.itemStatusId !== "INV_COUNT_REJECTED")

--- a/src/store/modules/product/actions.ts
+++ b/src/store/modules/product/actions.ts
@@ -94,6 +94,10 @@ const actions: ActionTree<ProductState, RootState> = {
     return {};
   },
 
+  async addProductToCached({ commit }, payload) {
+    commit(types.PRODUCT_ADD_TO_CACHED, payload);
+  },
+
   async clearProducts({ commit }) {
     commit(types.PRODUCT_LIST_UPDATED, { products: [], total: 0 });
   },

--- a/src/store/modules/product/mutations.ts
+++ b/src/store/modules/product/mutations.ts
@@ -11,10 +11,8 @@ const mutations: MutationTree <ProductState> = {
     }
   },
   [types.PRODUCT_ADD_TO_CACHED] (state, payload) {
-    if (payload.products) {
-      payload.products.forEach((product: any) => {
-        state.cached[product.productId] = product
-      });
+    if(payload.productId) {
+      state.cached[payload.productId] = payload
     }
   },
   [types.PRODUCT_CURRENT_UPDATED] (state, payload) {

--- a/src/views/HardCountDetail.vue
+++ b/src/views/HardCountDetail.vue
@@ -393,7 +393,8 @@ async function addProductToItemsList() {
     scannedId: queryString.value,
     isMatching: true,
     itemStatusId: "INV_COUNT_CREATED",
-    statusId: "INV_COUNT_ASSIGNED"
+    statusId: "INV_COUNT_ASSIGNED",
+    inventoryCountImportId: cycleCount.value.inventoryCountImportId
   }
 
   const items = JSON.parse(JSON.stringify(cycleCountItems.value.itemList))
@@ -432,12 +433,12 @@ async function addProductToCount(productId: any) {
   return 0;
 }
 
-async function updateCurrentItemInList(importItemSeqId: any, product: any, scannedValue: string) {
+async function updateCurrentItemInList(importItemSeqId: any, product: any, scannedValue: string, isMatchedUpdate = false) {
   const items = JSON.parse(JSON.stringify(cycleCountItems.value.itemList));
   const updatedProduct = JSON.parse(JSON.stringify(currentProduct.value))
   let prevItem = {} as any, hasErrorSavingCount = false;
 
-  if(updatedProduct.scannedId === scannedValue) {
+  if(updatedProduct.scannedId === scannedValue && !isMatchedUpdate) {
     if(importItemSeqId) {
       updatedProduct["importItemSeqId"] = importItemSeqId
       updatedProduct["productId"] = product.productId
@@ -447,7 +448,7 @@ async function updateCurrentItemInList(importItemSeqId: any, product: any, scann
     }
     updatedProduct["isMatching"] = false;
     store.dispatch("product/currentProduct", updatedProduct);
-  } else if(importItemSeqId) {
+  } else if(importItemSeqId && isMatchedUpdate) {
     prevItem = items.find((item: any) => item.scannedId === scannedValue);
 
     if(prevItem && prevItem?.scannedCount >= 0) {
@@ -462,6 +463,11 @@ async function updateCurrentItemInList(importItemSeqId: any, product: any, scann
   
         if(hasError(resp)) {
           hasErrorSavingCount = true;
+          updatedProduct["isMatching"] = false;
+          updatedProduct["isMatchNotFound"] = false
+          updatedProduct["importItemSeqId"] = importItemSeqId
+          updatedProduct["productId"] = product.productId
+          updatedProduct["productId"] = updatedProduct.scannedCount
         }
       } catch(error) {
         logger.error(error)
@@ -479,7 +485,10 @@ async function updateCurrentItemInList(importItemSeqId: any, product: any, scann
         item["isMatchNotFound"] = true
       }
       item["isMatching"] = false;
-      if(prevItem && Object.keys(prevItem)?.length && !hasErrorSavingCount) delete item["scannedCount"]
+      if(prevItem && Object.keys(prevItem)?.length && !hasErrorSavingCount) {
+        item["quantity"] = item.scannedCount
+        delete item["scannedCount"]
+      }
     }
   })
 
@@ -622,7 +631,7 @@ async function matchProduct(currentProduct: any) {
     if(result.data.selectedProduct) {
       const product = result.data.selectedProduct
       const importItemSeqId = await addProductToCount(product.productId)
-      updateCurrentItemInList(importItemSeqId, product, currentProduct.scannedId);
+      updateCurrentItemInList(importItemSeqId, product, currentProduct.scannedId, true);
     }
   })
 

--- a/src/views/HardCountDetail.vue
+++ b/src/views/HardCountDetail.vue
@@ -622,7 +622,7 @@ async function matchProduct(currentProduct: any) {
     if(result.data.selectedProduct) {
       const product = result.data.selectedProduct
       const importItemSeqId = await addProductToCount(product.productId)
-      updateCurrentItemInList(importItemSeqId, product.productId, currentProduct.scannedId);
+      updateCurrentItemInList(importItemSeqId, product, currentProduct.scannedId);
     }
   })
 


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#528

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
- Fixed the issue in matching product data manually using match product modal.
- Improved the matched product state handling to add the matched product in the cached state for future use.


### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I have read and followed [contribution rules](https://github.com/hotwax/inventory-count#contribution-guideline)
