### PR TITLE
Improved: clearing the hard count component state on leaving the component and added empty state (#528)

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -172,6 +172,8 @@
   "Nearest due": "Nearest due",
   "No cycle counts found": "No cycle counts found",
   "No data found": "No data found",
+  "No facility found.": "No facility found.",
+  "No facility group found.": "No facility group found.",
   "No items found": "No items found",
   "No new file upload. Please try again.": "No new file upload. Please try again.",
   "No products found.": "No products found.",

--- a/src/views/HardCount.vue
+++ b/src/views/HardCount.vue
@@ -7,7 +7,7 @@
       </ion-toolbar>
     </ion-header>
 
-    <ion-content class="main-content" ref="contentRef" :scroll-events="true" @ionScroll="enableScrolling()">
+    <ion-content class="main-content" ref="contentRef" :scroll-events="true" @ionScroll="selectedSegment === 'individual' ? enableScrolling() : ''">
       <div class="header">
         <div class="search">
           <ion-item lines="none" class="ion-padding">

--- a/src/views/HardCountDetail.vue
+++ b/src/views/HardCountDetail.vue
@@ -463,18 +463,25 @@ async function updateCurrentItemInList(newItem: any, scannedValue: string) {
   updatedItem = { ...updatedItem, ...newItem, isMatching: false }
   updatedItem["isMatchNotFound"] = newItem?.importItemSeqId ? false : true
 
+  let newCount = "" as any;
   if(updatedItem && updatedItem.scannedId !== updatedProduct.scannedId && updatedItem?.scannedCount) {
+    newCount = updatedItem.scannedCount
+  } else if(selectedSegment.value === "unmatched") {
+    newCount = Number(inputCount.value || 0) + Number(updatedItem.scannedCount || 0)
+  }
+
+  if(newCount) {
     try {
       const resp = await CountService.updateCount({
         inventoryCountImportId: cycleCount.value.inventoryCountImportId,
         importItemSeqId: updatedItem?.importItemSeqId,
         productId: updatedItem.productId,
-        quantity: updatedItem.scannedCount,
+        quantity: newCount,
         countedByUserLoginId: userProfile.value.username
       })
-
-      if(hasError(resp)) {
-        updatedItem["quantity"] = updatedItem.scannedCount
+  
+      if(!hasError(resp)) {
+        updatedItem["quantity"] = newCount
         delete updatedItem["scannedCount"];
       }
     } catch(error) {
@@ -629,7 +636,7 @@ async function matchProduct(currentProduct: any) {
     if(result.data?.selectedProduct) {
       const product = result.data.selectedProduct
       const newItem = await addProductToCount(product.productId)
-      updateCurrentItemInList(newItem, currentProduct.scannedId);
+      await updateCurrentItemInList(newItem, currentProduct.scannedId);
     }
   })
 

--- a/src/views/HardCountDetail.vue
+++ b/src/views/HardCountDetail.vue
@@ -466,7 +466,7 @@ async function updateCurrentItemInList(newItem: any, scannedValue: string) {
   let newCount = "" as any;
   if(updatedItem && updatedItem.scannedId !== updatedProduct.scannedId && updatedItem?.scannedCount) {
     newCount = updatedItem.scannedCount
-  } else if(selectedSegment.value === "unmatched") {
+  } else if(selectedSegment.value === "unmatched" && (inputCount.value || updatedItem.scannedCount)) {
     newCount = Number(inputCount.value || 0) + Number(updatedItem.scannedCount || 0)
   }
 
@@ -483,6 +483,7 @@ async function updateCurrentItemInList(newItem: any, scannedValue: string) {
       if(!hasError(resp)) {
         updatedItem["quantity"] = newCount
         delete updatedItem["scannedCount"];
+        inputCount.value = ""
       }
     } catch(error) {
       logger.error(error)


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#528

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->

- Clearing the hard count component state on leaving the component.
- Added empty state for no facility or facilityGroup in hard count.
- Saving the product count when the unmatched product is matched in the unmatched segment.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->
![Screenshot from 2024-12-27 14-47-58](https://github.com/user-attachments/assets/19c58ca6-7095-4f5b-8bf2-bf2de7bf3dd9)


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I have read and followed [contribution rules](https://github.com/hotwax/inventory-count#contribution-guideline)
