### PR TITLE
Improved: empty state in case of no cycle count items and UI for the counted count for hard count (#555)

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -138,6 +138,7 @@
   "inventory variance": "inventory variance", 
   "Instance Url": "Instance Url",
   "items": "items",
+  "item counted": "item counted",
   "items counted": "items counted",
   "Item has been removed from the cycle count": "Item has been removed from the cycle count",
   "Item added to upload list": "Item added to upload list",

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -92,9 +92,13 @@ function timeFromNow(time: any) {
   return DateTime.local().plus(timeDiff).toRelative();
 }
 
-function getCycleCountStats(id: string) {
+function getCycleCountStats(id: string, isHardCount = false) {
   const stats = cycleCountStats(id)
-  return stats ? `${stats.itemCounted}/${stats.totalItems}` : "0/0"
+  if(stats) {
+    return isHardCount ? `${stats.itemCounted}` : `${stats.itemCounted}/${stats.totalItems}`
+  } else {
+    return isHardCount ? "0" : "0/0"
+  }
 }
 
 function getFacilityName(id: string) {

--- a/src/views/Assigned.vue
+++ b/src/views/Assigned.vue
@@ -34,7 +34,7 @@
           
           <ion-label>
             <!-- TODO: make it dynamic currently not getting stats correctly -->
-            {{ getCycleCountStats(count.inventoryCountImportId) }}
+            {{ getCycleCountStats(count.inventoryCountImportId, count.countTypeEnumId === "HARD_COUNT") }}
             <p>{{ translate("counted") }}</p>
           </ion-label>
 

--- a/src/views/AssignedDetail.vue
+++ b/src/views/AssignedDetail.vue
@@ -56,7 +56,7 @@
           </div>
           <div class="filters ion-padding">
             <ion-list>
-              <ion-item>
+              <ion-item v-if="currentCycleCount.countTypeEnumId !== 'HARD_COUNT'">
                 <ion-label>{{ translate("Progress") }}</ion-label>
                 <ion-label slot="end">{{ getProgress() }}</ion-label>
               </ion-item>
@@ -118,7 +118,7 @@
           </div>
         </template>
         <p v-else class="empty-state">
-          {{ translate("No items found") }}
+          {{ translate("No items added to count") }}
         </p>
       </template>
       <template v-else>

--- a/src/views/Closed.vue
+++ b/src/views/Closed.vue
@@ -47,7 +47,7 @@
           </ion-chip>
 
           <ion-label>
-            {{ getCycleCountStats(count.inventoryCountImportId) }}
+            {{ getCycleCountStats(count.inventoryCountImportId, count.countTypeEnumId === "HARD_COUNT") }}
             <p>{{ translate("products counted") }}</p>
           </ion-label>
 

--- a/src/views/Count.vue
+++ b/src/views/Count.vue
@@ -58,7 +58,7 @@
                     <p>{{ getDateWithOrdinalSuffix(count.createdDate) }}</p>
                   </ion-label>
                 </ion-card-title>
-                <ion-note>{{ getCycleCountStats(count.inventoryCountImportId) }} {{ translate("items counted") }}</ion-note>
+                <ion-note>{{ getCycleCountStats(count.inventoryCountImportId, count.countTypeEnumId === "HARD_COUNT") }} {{ translate("items counted") }}</ion-note>
               </ion-card-header>
               <ion-item>
                 {{ translate("Due date") }}
@@ -83,7 +83,7 @@
                     <p>{{ getDateWithOrdinalSuffix(count.createdDate) }}</p>
                   </ion-label>
                 </ion-card-title>
-                <ion-note>{{ getCycleCountStats(count.inventoryCountImportId) }} {{ translate("items counted") }}</ion-note>
+                <ion-note>{{ getCycleCountStats(count.inventoryCountImportId, count.countTypeEnumId === "HARD_COUNT") }} {{ translate("items counted") }}</ion-note>
               </ion-card-header>
               <div class="header">
                 <div class="search">

--- a/src/views/Count.vue
+++ b/src/views/Count.vue
@@ -58,7 +58,7 @@
                     <p>{{ getDateWithOrdinalSuffix(count.createdDate) }}</p>
                   </ion-label>
                 </ion-card-title>
-                <ion-note>{{ getCycleCountStats(count.inventoryCountImportId, count.countTypeEnumId === "HARD_COUNT") }} {{ translate("items counted") }}</ion-note>
+                <ion-note>{{ getCycleCountStats(count.inventoryCountImportId, count.countTypeEnumId === "HARD_COUNT") }} {{ translate((count.countTypeEnumId === "HARD_COUNT" && getCycleCountStats(count.inventoryCountImportId, count.countTypeEnumId === "HARD_COUNT") === "1") ? "item counted" : "items counted") }}</ion-note>
               </ion-card-header>
               <ion-item>
                 {{ translate("Due date") }}
@@ -83,7 +83,7 @@
                     <p>{{ getDateWithOrdinalSuffix(count.createdDate) }}</p>
                   </ion-label>
                 </ion-card-title>
-                <ion-note>{{ getCycleCountStats(count.inventoryCountImportId, count.countTypeEnumId === "HARD_COUNT") }} {{ translate("items counted") }}</ion-note>
+                <ion-note>{{ getCycleCountStats(count.inventoryCountImportId, count.countTypeEnumId === "HARD_COUNT") }} {{ translate((count.countTypeEnumId === "HARD_COUNT" && getCycleCountStats(count.inventoryCountImportId, count.countTypeEnumId === "HARD_COUNT") === "1") ? "item counted" : "items counted") }}</ion-note>
               </ion-card-header>
               <div class="header">
                 <div class="search">

--- a/src/views/CountDetail.vue
+++ b/src/views/CountDetail.vue
@@ -201,7 +201,7 @@
           </template>
           <template v-else>
             <div class="empty-state">
-              <p>{{ translate("No products found.") }}</p>
+              <p>{{ translate("No items added to count") }}</p>
             </div>
           </template>
         </main>

--- a/src/views/DraftDetail.vue
+++ b/src/views/DraftDetail.vue
@@ -99,7 +99,7 @@
               <ion-icon slot="icon-only" :icon="isProductAvailableInCycleCount ? checkmarkCircle : addCircleOutline"/>
             </ion-button>
           </ion-item>
-          <p v-else-if="queryString">{{ translate("No product found") }}</p>
+          <p v-else-if="queryString">{{ translate("No items added to count") }}</p>
         </div>
 
         <hr />

--- a/src/views/PendingReview.vue
+++ b/src/views/PendingReview.vue
@@ -34,7 +34,7 @@
           
           <ion-label>
             <!-- TODO: make it dynamic currently not getting stats correctly -->
-            {{ getCycleCountStats(count.inventoryCountImportId) }}
+            {{ getCycleCountStats(count.inventoryCountImportId, count.countTypeEnumId === "HARD_COUNT") }}
             <p>{{ translate("counted") }}</p>
           </ion-label>
 

--- a/src/views/PendingReviewDetail.vue
+++ b/src/views/PendingReviewDetail.vue
@@ -153,7 +153,7 @@
         </template>
 
         <p v-else class="empty-state">
-          {{ translate("No items found") }}
+          {{ translate("No items added to count") }}
         </p>
       </template>
       <template v-else>


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#555

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
- Updated the empty state message to be shown when no item is present in the cycle counts in admin screens.
- UI for the count of counted items in the admin screens.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I have read and followed [contribution rules](https://github.com/hotwax/inventory-count#contribution-guideline)
