### PR TITLE
Improved: sending additional field while cycleCount creation for backend compatibility (#578)

### DIFF
--- a/src/views/Draft.vue
+++ b/src/views/Draft.vue
@@ -84,11 +84,13 @@ import Filters from "@/components/Filters.vue"
 import store from "@/store";
 import { showToast } from "@/utils";
 import router from "@/router";
+import { DateTime } from "luxon";
 
 const cycleCounts = computed(() => store.getters["count/getCounts"])
 const cycleCountStats = computed(() => (id: string) => store.getters["count/getCycleCountStats"](id))
 const isScrollable = computed(() => store.getters["count/isCycleCountListScrollable"])
 const query = computed(() => store.getters["count/getQuery"])
+const userProfile = computed(() => store.getters["user/getUserProfile"])
 
 const isScrollingEnabled = ref(false);
 const contentRef = ref({}) as any
@@ -179,7 +181,9 @@ async function createCycleCount() {
       // When initially creating the cycleCount we are just assigning it a name, all the other params are updated from the details page
       await store.dispatch("count/createCycleCount", {
         countImportName: name,
-        statusId: "INV_COUNT_CREATED"
+        statusId: "INV_COUNT_CREATED",
+        uploadedByUserLogin: userProfile.value.username,
+        createdDate: DateTime.now().toMillis()
       })
     }
   })

--- a/src/views/HardCount.vue
+++ b/src/views/HardCount.vue
@@ -151,6 +151,7 @@ const countNameRef = ref("") as Ref<any>;
 const infiniteScrollRef = ref("");
 
 const facilityGroups = computed(() => store.getters["util/getFacilityGroups"])
+const userProfile = computed(() => store.getters["user/getUserProfile"])
 
 onIonViewWillEnter(async () => {
   countName.value = `Hard count - ${DateTime.now().toFormat('dd-MM-yyyy hh:mm:ss')}`;
@@ -178,7 +179,9 @@ async function saveCount() {
   let count = {
     countImportName: countName.value,
     statusId: isAutoAssignEnabled.value ? "INV_COUNT_ASSIGNED" : "INV_COUNT_CREATED",
-    countTypeEnumId: "HARD_COUNT"
+    countTypeEnumId: "HARD_COUNT",
+    uploadedByUserLogin: userProfile.value.username,
+    createdDate: DateTime.now().toMillis()
   } as any;
 
   if(dueDate.value) count["dueDate"] = dueDate.value;


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#578

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
Sending below fields while the creation of cycle count for the backend compatitbility.
- uploadedByUserLoginId
- createdDate

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I have read and followed [contribution rules](https://github.com/hotwax/inventory-count#contribution-guideline)
