### PR TITLE
Improved: route for hard counts detail age, highlighting the tab for count details page, persisting detail when moving back from settings to count(#580)

### DIFF
--- a/src/components/Menu.vue
+++ b/src/components/Menu.vue
@@ -68,7 +68,7 @@ export default defineComponent({
         url: "/draft",
         iosIcon: createOutline,
         mdIcon: createOutline,
-        childRoutes: ["/draft/", "/bulkUpload", "/hard-count", "/hard-count-detail"],
+        childRoutes: ["/draft/", "/bulkUpload", "/hard-count"],
         meta: {
           permissionId: "APP_DRAFT_VIEW"
         }

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -84,7 +84,7 @@ const routes: Array<RouteRecordRaw> = [
         }
       },
       {
-        path: 'hard-count-detail/:id',
+        path: 'count-detail/hard/:id',
         name: 'HardCountDetail',
         component: HardCountDetail,
         props: true,

--- a/src/views/Count.vue
+++ b/src/views/Count.vue
@@ -229,7 +229,7 @@ async function segmentChanged(value) {
 }
 
 function navigateToStoreView(count) {
-  router.push((count.countTypeEnumId === "HARD_COUNT" && count.statusId === "INV_COUNT_ASSIGNED") ? `/tabs/hard-count-detail/${count.inventoryCountImportId}` : `/tabs/count-detail/${count.inventoryCountImportId}`);
+  router.push((count.countTypeEnumId === "HARD_COUNT" && count.statusId === "INV_COUNT_ASSIGNED") ? `/tabs/count-detail/hard/${count.inventoryCountImportId}` : `/tabs/count-detail/${count.inventoryCountImportId}`);
 }
 
 function getStatusIdForCountsToBeFetched() {

--- a/src/views/Tabs.vue
+++ b/src/views/Tabs.vue
@@ -3,7 +3,7 @@
     <ion-tabs>
       <ion-router-outlet></ion-router-outlet>
       <ion-tab-bar slot="bottom">
-        <ion-tab-button tab="orders" @click="$router.push('/tabs/count')" href="/tabs/count">
+        <ion-tab-button tab="orders" href="/tabs/count">
           <ion-icon :icon="infiniteOutline" />
           <ion-label>{{ translate("Counts") }}</ion-label>
         </ion-tab-button>


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->
#560
#580

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
- Updated the route for the hard count details.
- Highlighting the count tab for count details page.
- Persisiting the previous state when moving form count detail to settings.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I have read and followed [contribution rules](https://github.com/hotwax/inventory-count#contribution-guideline)
