### PR TITLE
Improved: scrolling to the first element on removing the last item (#567)

### DIFF
--- a/src/views/HardCountDetail.vue
+++ b/src/views/HardCountDetail.vue
@@ -354,6 +354,7 @@ function removeCountItem(current: any) {
 
   store.dispatch("count/updateCycleCountItems", updatedItems);
   store.dispatch("product/currentProduct", updatedProduct ? updatedProduct : {})
+  if(updatedProduct) scrollToProduct(updatedProduct);
 }
 
 async function scanProduct() {


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#567

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
Scrolling the first item into view when removing the last item from the cycle count.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I have read and followed [contribution rules](https://github.com/hotwax/inventory-count#contribution-guideline)
