### PR TITLE
Fixed: count name not updating on UI post successfull api call and duplicate facility coming on infinite scrolling (#528)

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -126,7 +126,7 @@
   "Group": "Group",
   "Hard Count": "Hard Count",
   "HARD COUNT": "HARD COUNT",
-  "Hard counts are used when conducting large scale full counts at facilities. Products are not added to hard counts before they’re assigned. Facilities will count everything they have in stock. Anything they don’t count will defaulted to 0 on hand.": "Hard counts are used when conducting large scale full counts at facilities. Products are not added to hard counts before they’re assigned. Facilities will count everything they have in stock. Anything they don’t count will defaulted to 0 on hand.",
+  "Hard counts are used when conducting large scale full counts at facilities. Products are not added to hard counts before they’re assigned. Facilities will count everything they have in stock. Anything they don’t count will be defaulted to 0 on hand.": "Hard counts are used when conducting large scale full counts at facilities. Products are not added to hard counts before they’re assigned. Facilities will count everything they have in stock. Anything they don’t count will be defaulted to 0 on hand.",
   "If a file includes multiple facilities, a count is created for every facility. All items with no facility location will be added to the same count.": "If a file includes multiple facilities, a count is created for every facility. All items with no facility location will be added to the same count.",
   "Import CSV": "Import CSV",
   "Import Error": "Import Error",

--- a/src/views/AssignedDetail.vue
+++ b/src/views/AssignedDetail.vue
@@ -259,12 +259,12 @@ async function updateCountName() {
   }
 
   if(countName.value.trim() !== currentCycleCount.value.countName?.trim()) {
-    const inventoryCountImportId = await CountService.updateCycleCount({ inventoryCountImportId: currentCycleCount.value.countId, countImportName: countName.value.trim() })
-    if(inventoryCountImportId) {
+    await CountService.updateCycleCount({ inventoryCountImportId: currentCycleCount.value.countId, countImportName: countName.value.trim() })
+    .then(() => {
       currentCycleCount.value.countName = countName.value.trim()
-    } else {
+    }).catch(() => {
       countName.value = currentCycleCount.value.countName.trim()
-    }
+    })
   }
 
   isCountNameUpdating.value = false

--- a/src/views/DraftDetail.vue
+++ b/src/views/DraftDetail.vue
@@ -363,12 +363,12 @@ async function updateCountName() {
   }
 
   if(countName.value.trim() !== currentCycleCount.value.countName.trim()) {
-    const inventoryCountImportId = await CountService.updateCycleCount({ inventoryCountImportId: currentCycleCount.value.countId, countImportName: countName.value.trim() })
-    if(inventoryCountImportId) {
+    await CountService.updateCycleCount({ inventoryCountImportId: currentCycleCount.value.countId, countImportName: countName.value.trim() })
+    .then(() => {
       currentCycleCount.value.countName = countName.value.trim()
-    } else {
+    }).catch(() => {
       countName.value = currentCycleCount.value.countName.trim()
-    }
+    })
   }
 
   isCountNameUpdating.value = false

--- a/src/views/HardCount.vue
+++ b/src/views/HardCount.vue
@@ -22,7 +22,7 @@
             </ion-button>
           </ion-item>
           <ion-item lines="none">
-            <ion-label>{{ translate("Hard counts are used when conducting large scale full counts at facilities. Products are not added to hard counts before they’re assigned. Facilities will count everything they have in stock. Anything they don’t count will defaulted to 0 on hand.") }}</ion-label>
+            <ion-label>{{ translate("Hard counts are used when conducting large scale full counts at facilities. Products are not added to hard counts before they’re assigned. Facilities will count everything they have in stock. Anything they don’t count will be defaulted to 0 on hand.") }}</ion-label>
           </ion-item>
 
           
@@ -238,7 +238,8 @@ async function fetchFacilities(vSize?: any, vIndex?: any) {
     facilityTypeId: "VIRTUAL_FACILITY",
     facilityTypeId_not: "Y",
     parentTypeId: "VIRTUAL_FACILITY",
-    parentTypeId_not: "Y"
+    parentTypeId_not: "Y",
+    orderByField: "facilityName"
   } as any;
 
   if(queryString.value.trim()) {

--- a/src/views/PendingReviewDetail.vue
+++ b/src/views/PendingReviewDetail.vue
@@ -346,12 +346,12 @@ async function updateCountName() {
   }
 
   if(countName.value.trim() !== currentCycleCount.value.countName.trim()) {
-    const inventoryCountImportId = await CountService.updateCycleCount({ inventoryCountImportId: currentCycleCount.value.countId, countImportName: countName.value.trim() })
-    if(inventoryCountImportId) {
+    await CountService.updateCycleCount({ inventoryCountImportId: currentCycleCount.value.countId, countImportName: countName.value.trim() })
+    .then(() => {
       currentCycleCount.value.countName = countName.value.trim()
-    } else {
+    }).catch(() => {
       countName.value = currentCycleCount.value.countName.trim()
-    }
+    })
   }
 
   isCountNameUpdating.value = false


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#528

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
- Fixed count name not updating on UI on successful api call for name updation.
- Sorting by facilityName while fetching the facilities to avoid duplicate facility coming on infinite scrolling.
- Updated the hard count creation page description.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I have read and followed [contribution rules](https://github.com/hotwax/inventory-count#contribution-guideline)
