### PR TITLE
Fixed: wrong count displayed in the rejected count item in closed segment (#605)

### DIFF
--- a/src/views/Count.vue
+++ b/src/views/Count.vue
@@ -124,7 +124,7 @@
                   <ion-item>
                     {{ translate("Rejected") }}
                     <ion-label slot="end">
-                      <p>{{ cycleCountStats(count.inventoryCountImportId)?.totalItems }}</p>
+                      <p>{{ cycleCountStats(count.inventoryCountImportId)?.rejectedCount }}</p>
                     </ion-label>
                   </ion-item>
                   <ion-item>


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#605

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
Fixed the wrong count (total items count) getting displyed in the rejected count item in closed segment.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I have read and followed [contribution rules](https://github.com/hotwax/inventory-count#contribution-guideline)
