### PR TITLE
Fixed: download count issue when product information is not available from solr(#617)

### DIFF
--- a/src/components/DownloadClosedCountModal.vue
+++ b/src/components/DownloadClosedCountModal.vue
@@ -243,8 +243,7 @@ async function downloadCSV() {
   const downloadData = await Promise.all(cycleCountItems.map(async (item: any) => {
     const facility = facilityDetails[item?.facilityId];
     const product = getProduct.value(item.productId)
-  
-    if(product.productId) {
+
       const cycleCountDetails = selectedData.reduce((details: any, property: any) => {
         if (property === 'createdDate') {
           details[property] = getDateWithOrdinalSuffix(item.createdDate);
@@ -255,8 +254,8 @@ async function downloadCSV() {
         } else if (property === 'facility') {
           details[property] = facility[selectedFacilityField.value];
         } else if (property === 'primaryProductId') {
-          details[property] = getProductIdentificationValue(selectedPrimaryProductId.value, product);
-        } else if (property === 'secondaryProductId') {
+          details[property] = product.productId ? getProductIdentificationValue(selectedPrimaryProductId.value, product) : item.productId;
+        } else if (product.productId && property === 'secondaryProductId') {
           details[property] = getProductIdentificationValue(selectedSecondaryProductId.value, product);
         } else if (property === 'countName' && item.countImportName) {
           details[property] = item.countImportName;
@@ -267,9 +266,8 @@ async function downloadCSV() {
         }
         return details;
       }, {});
-    
+
       return cycleCountDetails;
-    }      
   }));
   
   const fileName = `CycleCounts-${DateTime.now().toLocaleString(DateTime.DATETIME_MED_WITH_SECONDS)}.csv`;


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#617

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
When downloading closed count report and if for some product the information is not available from solr, then in that case we get undefined in the item details resulting in jsonToCsv parse failure.
Removed the check for productId when preparing the download and added the check on specific fields value.
If the product information is not available from solr then the downloaded report does not contain any product specific data for that product, so in that case by default added productId from the count

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I have read and followed [contribution rules](https://github.com/hotwax/inventory-count#contribution-guideline)
