### PR TITLE
Fixed: On reload of the pending review details page, the loader will remain visible until the items list is updated (#629)

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -12,7 +12,7 @@
 
 <script setup lang="ts">
 import { IonApp, IonRouterOutlet, IonSplitPane } from '@ionic/vue';
-import { computed, onMounted, onUnmounted, ref } from 'vue';
+import { computed, onBeforeMount, onUnmounted, ref } from 'vue';
 import { loadingController } from '@ionic/vue';
 import emitter from "@/event-bus"
 import { initialise, resetConfig } from '@/adapter'
@@ -65,13 +65,7 @@ function dismissLoader() {
   }
 }
 
-onMounted(async () => {
-  loader.value = await loadingController
-    .create({
-      message: translate("Click the backdrop to dismiss."),
-      translucent: true,
-      backdropDismiss: true
-    });
+onBeforeMount(async () => {
   emitter.on("presentLoader", presentLoader);
   emitter.on("dismissLoader", dismissLoader);
 

--- a/src/App.vue
+++ b/src/App.vue
@@ -12,7 +12,7 @@
 
 <script setup lang="ts">
 import { IonApp, IonRouterOutlet, IonSplitPane } from '@ionic/vue';
-import { computed, onBeforeMount, onUnmounted, ref } from 'vue';
+import { computed, onBeforeMount, onMounted, onUnmounted, ref } from 'vue';
 import { loadingController } from '@ionic/vue';
 import emitter from "@/event-bus"
 import { initialise, resetConfig } from '@/adapter'
@@ -68,7 +68,9 @@ function dismissLoader() {
 onBeforeMount(async () => {
   emitter.on("presentLoader", presentLoader);
   emitter.on("dismissLoader", dismissLoader);
+})
 
+onMounted(async () => {
   if (userProfile.value) {
     // Luxon timezone should be set with the user's selected timezone
     userProfile.value.timeZone && (Settings.defaultZone = userProfile.value.timeZone);

--- a/src/App.vue
+++ b/src/App.vue
@@ -65,7 +65,7 @@ function dismissLoader() {
   }
 }
 
-onBeforeMount(async () => {
+onBeforeMount(() => {
   emitter.on("presentLoader", presentLoader);
   emitter.on("dismissLoader", dismissLoader);
 })

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -173,6 +173,7 @@
   "No facility found.": "No facility found.",
   "No facility group found.": "No facility group found.",
   "No items found": "No items found",
+  "No items added to count": "No items added to count",
   "No new file upload. Please try again.": "No new file upload. Please try again.",
   "No products found.": "No products found.",
   "no match found": "no match found",


### PR DESCRIPTION

### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#629 

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
- Previously, on reload, the `onMounted` hook in `App.vue` was running after the `onIonViewWillEnter` hook in the displayed component, which emits the loader event. This caused a mismatch in the sequence of event handling. To address this, the `onMounted` hook was replaced with the `onBeforeMount` hook.  
- Removed the logic of creating the loader from the `onBeforeMount` hook, as it was being handled asynchronously.  
- With these changes, the hook in `App.vue` now runs before the hook in the component, ensuring that the event listener is set up before the loader event is emitted from the component.  

### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I have read and followed [contribution rules](https://github.com/hotwax/inventory-count#contribution-guideline)
