### PR TITLE
 Improved: Added a check to allow completing the pending count only when no items are in the "created" state(#635)

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -312,6 +312,7 @@
   "Total variance": "Total variance",
   "total variance": "total variance",
   "UNMATCHED": "UNMATCHED",
+  "Unable to complete the count as some items are still pending review. Please review the updated item list and try again": "Unable to complete the count as some items are still pending review. Please review the updated item list and try again",
   "Update": "Update",
   "Update count": "Update count",
   "Upload count": "Upload count",

--- a/src/services/CountService.ts
+++ b/src/services/CountService.ts
@@ -33,6 +33,14 @@ const fetchCycleCountItems = async (payload: any): Promise<any> => {
   })
 }
 
+const fetchCycleCountItemStatus = async (payload: any): Promise<any> => {
+  return api({
+    url: `cycleCounts/${payload.inventoryCountImportId}/items/count`,
+    method: "GET",
+    params: payload
+  })
+}
+
 const fetchBulkCycleCountItems = async (payload: any): Promise<any> => {
   return api({
     url: "cycleCounts/items",
@@ -176,6 +184,7 @@ export const CountService = {
   fetchCycleCountStats,
   fetchCycleCounts,
   fetchCycleCountItems,
+  fetchCycleCountItemStatus,
   fetchCycleCountsTotal,
   recountItems,
   updateCount,

--- a/src/services/CountService.ts
+++ b/src/services/CountService.ts
@@ -33,7 +33,7 @@ const fetchCycleCountItems = async (payload: any): Promise<any> => {
   })
 }
 
-const fetchCycleCountItemStatus = async (payload: any): Promise<any> => {
+const fetchCycleCountItemsCount = async (payload: any): Promise<any> => {
   return api({
     url: `cycleCounts/${payload.inventoryCountImportId}/items/count`,
     method: "GET",
@@ -184,7 +184,7 @@ export const CountService = {
   fetchCycleCountStats,
   fetchCycleCounts,
   fetchCycleCountItems,
-  fetchCycleCountItemStatus,
+  fetchCycleCountItemsCount,
   fetchCycleCountsTotal,
   recountItems,
   updateCount,

--- a/src/views/PendingReviewDetail.vue
+++ b/src/views/PendingReviewDetail.vue
@@ -485,7 +485,7 @@ async function recountItem(item?: any) {
 
 async function completeCount() {
   try {
-    const resp = await CountService.fetchCycleCountItemStatus({
+    const resp = await CountService.fetchCycleCountItemsCount({
       inventoryCountImportId: props?.inventoryCountImportId,
       statusId: "INV_COUNT_CREATED",
     })

--- a/src/views/PendingReviewDetail.vue
+++ b/src/views/PendingReviewDetail.vue
@@ -486,8 +486,8 @@ async function recountItem(item?: any) {
 async function completeCount() {
   try {
     const resp = await CountService.fetchCycleCountItemStatus({
-      inventoryCountImportId : props?.inventoryCountImportId,
-      statusId : "INV_COUNT_CREATED",
+      inventoryCountImportId: props?.inventoryCountImportId,
+      statusId: "INV_COUNT_CREATED",
     })
 
     if(!hasError(resp) && resp.data?.count > 0) {

--- a/src/views/PendingReviewDetail.vue
+++ b/src/views/PendingReviewDetail.vue
@@ -485,14 +485,29 @@ async function recountItem(item?: any) {
 
 async function completeCount() {
   try {
-    await CountService.updateCycleCount({
-      inventoryCountImportId: currentCycleCount.value.countId,
-      statusId: "INV_COUNT_COMPLETED"
+    const resp = await CountService.fetchCycleCountItemStatus({
+      inventoryCountImportId : props?.inventoryCountImportId,
+      statusId : "INV_COUNT_CREATED",
     })
-    router.push("/closed")
-    showToast(translate("Count has been marked as completed"))
+
+    if(!hasError(resp) && resp.data?.count > 0) {
+      await fetchCountItems();
+      showToast(translate("Cannot complete count as some items are still in created state. Please review the refreshed item list and try again."))
+      return;
+    }
+
+    try {
+      await CountService.updateCycleCount({
+        inventoryCountImportId: currentCycleCount.value.countId,
+        statusId: "INV_COUNT_COMPLETED"
+      })
+      router.push("/closed")
+      showToast(translate("Count has been marked as completed"))
+    } catch(err) {
+      showToast(translate("Failed to complete cycle count"))
+    }
   } catch(err) {
-    showToast(translate("Failed to complete cycle count"))
+    logger.error(err)
   }
 }
 

--- a/src/views/PendingReviewDetail.vue
+++ b/src/views/PendingReviewDetail.vue
@@ -492,7 +492,7 @@ async function completeCount() {
 
     if(!hasError(resp) && resp.data?.count > 0) {
       await fetchCountItems();
-      showToast(translate("Cannot complete count as some items are still in created state. Please review the refreshed item list and try again."))
+      showToast(translate("Unable to complete the count as some items are still pending review. Please review the updated item list and try again"))
       return;
     }
 
@@ -507,6 +507,7 @@ async function completeCount() {
       showToast(translate("Failed to complete cycle count"))
     }
   } catch(err) {
+    showToast(translate("Failed to complete cycle count"))
     logger.error(err)
   }
 }


### PR DESCRIPTION

### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#635 

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
- Added a check to prevent completing the pending count as long as any item in the count is in the "created" state. Completion will only be allowed when no items are in the "created" state.

### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I have read and followed [contribution rules](https://github.com/hotwax/inventory-count#contribution-guideline)
