### PR TITLE
Fixed: cached products not getting cleared on saving count (#647)

### DIFF
--- a/src/store/modules/count/actions.ts
+++ b/src/store/modules/count/actions.ts
@@ -212,9 +212,8 @@ const actions: ActionTree<CountState, RootState> = {
   },
 
   async fetchCycleCountItems({commit, state} ,payload) {
-    const cachedProducts = state.cachedUnmatchProducts[payload.inventoryCountImportId]?.length ? JSON.parse(JSON.stringify(state.cachedUnmatchProducts[payload.inventoryCountImportId])) : [];
     let items = [] as any, resp, pageIndex = 0;
-
+    
     try {
       do {
         resp = await CountService.fetchCycleCountItems({ ...payload, pageSize: 100, pageIndex })
@@ -232,7 +231,10 @@ const actions: ActionTree<CountState, RootState> = {
     if(payload.isSortingRequired) items = sortListByField(items, "parentProductName");
 
     this.dispatch("product/fetchProducts", { productIds: [...new Set(items.map((item: any) => item.productId))] })
-    if(cachedProducts?.length) items = items.concat(cachedProducts)
+    if(payload.hasCachedProducts) {
+      const cachedProducts = state.cachedUnmatchProducts[payload.inventoryCountImportId]?.length ? JSON.parse(JSON.stringify(state.cachedUnmatchProducts[payload.inventoryCountImportId])) : [];
+      if(cachedProducts?.length) items = items.concat(cachedProducts)
+    }
     commit(types.COUNT_ITEMS_UPDATED, { itemList: items })
   },
 

--- a/src/store/modules/count/actions.ts
+++ b/src/store/modules/count/actions.ts
@@ -231,7 +231,7 @@ const actions: ActionTree<CountState, RootState> = {
     if(payload.isSortingRequired) items = sortListByField(items, "parentProductName");
 
     this.dispatch("product/fetchProducts", { productIds: [...new Set(items.map((item: any) => item.productId))] })
-    if(payload.hasCachedProducts) {
+    if(payload.isHardCount) {
       const cachedProducts = state.cachedUnmatchProducts[payload.inventoryCountImportId]?.length ? JSON.parse(JSON.stringify(state.cachedUnmatchProducts[payload.inventoryCountImportId])) : [];
       if(cachedProducts?.length) items = items.concat(cachedProducts)
     }

--- a/src/views/HardCountDetail.vue
+++ b/src/views/HardCountDetail.vue
@@ -263,7 +263,7 @@ const isSubmittingForReview = ref(false);
 
 onIonViewDidEnter(async() => {  
   emitter.emit("presentLoader");
-  await Promise.allSettled([fetchCycleCount(),   await store.dispatch("count/fetchCycleCountItems", { inventoryCountImportId : props?.id, isSortingRequired: false, hasCachedProducts: true }), store.dispatch("user/getProductStoreSetting", currentFacility.value?.productStore?.productStoreId)])
+  await Promise.allSettled([fetchCycleCount(),   await store.dispatch("count/fetchCycleCountItems", { inventoryCountImportId : props?.id, isSortingRequired: false, isHardCount: true }), store.dispatch("user/getProductStoreSetting", currentFacility.value?.productStore?.productStoreId)])
   previousItem = itemsList.value[0];
   await store.dispatch("product/currentProduct", itemsList.value?.length ? itemsList.value[0] : {})
   barcodeInputRef.value?.$el?.setFocus();

--- a/src/views/HardCountDetail.vue
+++ b/src/views/HardCountDetail.vue
@@ -577,8 +577,8 @@ async function readyForReview() {
             inventoryCountImportId: props?.id,
             statusId: "INV_COUNT_REVIEW"
           })
-          router.push("/tabs/count")
           isSubmittingForReview.value = true;
+          router.push("/tabs/count")
           store.dispatch('count/clearCurrentCountFromCachedUnmatchProducts', props.id);
           showToast(translate("Count has been submitted for review"))
         } catch(err) {


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#647

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
Improved code to not add unmatched product in the cached state on saving count.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I have read and followed [contribution rules](https://github.com/hotwax/inventory-count#contribution-guideline)
