### PR TITLE
Implemented: Date range filter for cycle counts on the closed page (#619)

### DIFF
--- a/src/components/Filters.vue
+++ b/src/components/Filters.vue
@@ -156,18 +156,14 @@ function getMinDate() {
   return undefined;
 }
 
-// Returns the maximum allowed date for the current date filter, ensuring it is not after the "thru" date for closed or created dates.
+// Returns the maximum allowed date for the current filter, restricting "After" dates to today and allowing "Before" dates without restriction.
 function getMaxDate() {
   const dateFilterKey = currentDateFilter.value;
 
   if(dateFilterKey === 'closedDate_from' || dateFilterKey === 'createdDate_from') {
     return DateTime.now().toISODate();
-  } else if(dateFilterKey === 'closedDate_thru') {
-    const beforeDateClosed = query.value.closedDate_thru;
-    return beforeDateClosed ? DateTime.fromISO(beforeDateClosed).toISO() : undefined;
-  } else if(dateFilterKey === 'createdDate_thru') {
-    const beforeDateCreated = query.value.createdDate_thru;
-    return beforeDateCreated ? DateTime.fromISO(beforeDateCreated).toISO() : undefined;
+  } else if(dateFilterKey === 'closedDate_thru' || dateFilterKey === 'createdDate_thru') {
+    return undefined;
   }
   return undefined;
 }

--- a/src/components/Filters.vue
+++ b/src/components/Filters.vue
@@ -65,7 +65,7 @@
             </div>
           </ion-accordion>
 
-          <ion-accordion>
+          <ion-accordion v-if="router.currentRoute.value.name === 'Closed'">
             <ion-item slot="header" lines="full">
               <ion-icon slot="start" :icon="gitPullRequestOutline"/>
               <ion-label class="ion-text-wrap">{{ translate("Closed") }}</ion-label>
@@ -127,6 +127,7 @@ import { translate } from '@/i18n'
 import store from "@/store";
 import router from "@/router";
 import { DateTime } from "luxon";
+import { getDateWithOrdinalSuffix } from "@/utils";
 
 const dateTimeModalOpen = ref(false)
 const currentDateFilter = ref("");
@@ -159,10 +160,12 @@ function getMinDate() {
 function getMaxDate() {
   const dateFilterKey = currentDateFilter.value;
 
-  if(dateFilterKey === 'closedDate_from') {
+  if(dateFilterKey === 'closedDate_from' || dateFilterKey === 'createdDate_from') {
+    return DateTime.now().toISODate();
+  } else if(dateFilterKey === 'closedDate_thru') {
     const beforeDateClosed = query.value.closedDate_thru;
     return beforeDateClosed ? DateTime.fromISO(beforeDateClosed).toISO() : undefined;
-  } else if(dateFilterKey === 'createdDate_from') {
+  } else if(dateFilterKey === 'createdDate_thru') {
     const beforeDateCreated = query.value.createdDate_thru;
     return beforeDateCreated ? DateTime.fromISO(beforeDateCreated).toISO() : undefined;
   }
@@ -193,14 +196,14 @@ async function updateDateTimeFilter(date: any) {
 
 function formatDateTime(date: any) {
   const dateTime = DateTime.fromISO(date);
-  return dateTime.toFormat("dd'th' MMM yyyy");
+  return getDateWithOrdinalSuffix(dateTime.toMillis());
 }
 
 function showAdditionalFilters() {
   return {
     noFacility: router.currentRoute.value.name === "Draft",
     selectedFacilities: router.currentRoute.value.name === "Closed",
-    date: router.currentRoute.value.name === "Closed"
+    date: router.currentRoute.value.name !== "Draft"
   }
 }
 

--- a/src/components/Filters.vue
+++ b/src/components/Filters.vue
@@ -55,12 +55,12 @@
             </ion-item>
             <div slot="content">
               <ion-item>
-                <ion-label>{{ translate("Before") }}</ion-label>
-                <ion-button slot="end" size="small" class="date-time-button" @click="openDateTimeModal('createdDate', 'thru')">{{ query["createdDate"]["thru"] ? formatDateTime(query["createdDate"]["thru"]) : translate("Date") }}</ion-button>
-              </ion-item>
-              <ion-item>
                 <ion-label>{{ translate("After") }}</ion-label>
                 <ion-button slot="end" size="small" class="date-time-button" @click="openDateTimeModal('createdDate', 'from')">{{ query["createdDate"]["from"] ? formatDateTime(query["createdDate"]["from"]) : translate("Date") }}</ion-button>
+              </ion-item>
+              <ion-item>
+                <ion-label>{{ translate("Before") }}</ion-label>
+                <ion-button slot="end" size="small" class="date-time-button" @click="openDateTimeModal('createdDate', 'thru')">{{ query["createdDate"]["thru"] ? formatDateTime(query["createdDate"]["thru"]) : translate("Date") }}</ion-button>
               </ion-item>
             </div>
           </ion-accordion>
@@ -72,12 +72,12 @@
             </ion-item>
             <div slot="content">
               <ion-item>
-                <ion-label>{{ translate("Before") }}</ion-label>
-                <ion-button slot="end" size="small" class="date-time-button" @click="openDateTimeModal('closedDate', 'thru')">{{ query["closedDate"]["thru"] ? formatDateTime(query["closedDate"]["thru"]) : translate("Date") }}</ion-button>
-              </ion-item>
-              <ion-item>
                 <ion-label>{{ translate("After") }}</ion-label>
                 <ion-button slot="end" size="small" class="date-time-button" @click="openDateTimeModal('closedDate', 'from')">{{ query["closedDate"]["from"] ? formatDateTime(query["closedDate"]["from"]) : translate("Date") }}</ion-button>
+              </ion-item>
+              <ion-item>
+                <ion-label>{{ translate("Before") }}</ion-label>
+                <ion-button slot="end" size="small" class="date-time-button" @click="openDateTimeModal('closedDate', 'thru')">{{ query["closedDate"]["thru"] ? formatDateTime(query["closedDate"]["thru"]) : translate("Date") }}</ion-button>
               </ion-item>
             </div>
           </ion-accordion>  
@@ -86,10 +86,10 @@
           <ion-content force-overscroll="false">
             <ion-datetime 
               :value="currentDateTimeValue"
+              show-clear-button
               show-default-buttons
               presentation="date"
               @ionChange="updateDateTimeFilter($event.detail.value)"
-              :show-clear-button="currentDateTimeValue ? true : false"
             />
           </ion-content>
         </ion-modal>

--- a/src/components/Filters.vue
+++ b/src/components/Filters.vue
@@ -135,7 +135,7 @@ const query = computed(() => store.getters["count/getQuery"])
 
 function openDateTimeModal(dateType: any, dateRange: any) {
   currentFilter.value = `${dateType}_${dateRange}`;
-  currentDateTimeValue.value = query.value[dateType][dateRange] ? DateTime.fromMillis(query.value[dateType][dateRange]).toISO() : DateTime.now()
+  currentDateTimeValue.value = query.value[dateType][dateRange] ? query.value[dateType][dateRange] : DateTime.now()
   dateTimeModalOpen.value = true;
 }
 
@@ -153,14 +153,14 @@ async function updateDateTimeFilter(date: any) {
     key: dateType,
     value: {
       ...query.value[dateType],
-      [dateRange]: DateTime.fromISO(date).toMillis()
+      [dateRange]: date
     }
   }
   await store.dispatch("count/updateQuery", payload)
 }
 
-function formatDateTime(date: number) {
-  const dateTime = DateTime.fromMillis(date);
+function formatDateTime(date: any) {
+  const dateTime = DateTime.fromISO(date);
   return dateTime.toFormat("dd'th' MMM yyyy");
 }
 

--- a/src/store/modules/count/CountState.ts
+++ b/src/store/modules/count/CountState.ts
@@ -6,7 +6,9 @@ export default interface CountState {
     facilityIds: Array<string>,
     noFacility: boolean,
     queryString: string,
-    sortBy: string
+    sortBy: string,
+    createdDate: any
+    closedDate: any,
   },
   stats: any;
   cycleCounts: any;

--- a/src/store/modules/count/CountState.ts
+++ b/src/store/modules/count/CountState.ts
@@ -7,7 +7,10 @@ export default interface CountState {
     noFacility: boolean,
     queryString: string,
     sortBy: string,
-    dateFilter: any
+    createdDate_from: string,
+    createdDate_thru: string,
+    closedDate_from: string,
+    closedDate_thru: string
   },
   stats: any;
   cycleCounts: any;

--- a/src/store/modules/count/CountState.ts
+++ b/src/store/modules/count/CountState.ts
@@ -7,8 +7,7 @@ export default interface CountState {
     noFacility: boolean,
     queryString: string,
     sortBy: string,
-    createdDate: any
-    closedDate: any,
+    dateFilter: any
   },
   stats: any;
   cycleCounts: any;

--- a/src/store/modules/count/actions.ts
+++ b/src/store/modules/count/actions.ts
@@ -42,6 +42,28 @@ const actions: ActionTree<CountState, RootState> = {
       params["orderByField"] = state.query.sortBy
     }
 
+    if(state.query.createdDate) {
+      // created before date
+      if(state.query.createdDate?.thru) {
+        params["createdDate_thru"] = state.query.createdDate?.thru
+      }
+      // created after date
+      if(state.query.createdDate?.from) {
+        params["createdDate_from"] = state.query.createdDate?.from
+      } 
+    }
+
+    if(state.query.closedDate) {
+      // closed before date
+      if(state.query.closedDate?.thru) {
+        params["closedDate_thru"] = state.query.closedDate?.thru
+      }
+      // closed after date
+      if(state.query.closedDate?.from) {
+        params["closedDate_from"] = state.query.closedDate?.from
+      } 
+    }
+
     try {
       const resp = await CountService.fetchCycleCounts(params);
       if(!hasError(resp) && resp.data.length > 0) {

--- a/src/store/modules/count/actions.ts
+++ b/src/store/modules/count/actions.ts
@@ -42,26 +42,22 @@ const actions: ActionTree<CountState, RootState> = {
       params["orderByField"] = state.query.sortBy
     }
 
-    if(state.query.createdDate) {
-      // created before date
-      if(state.query.createdDate?.thru) {
-        params["createdDate_thru"] = convertIsoToMillis(state.query.createdDate.thru)
-      }
-      // created after date
-      if(state.query.createdDate?.from) {
-        params["createdDate_from"] = convertIsoToMillis(state.query.createdDate.from)
-      }
+    // created before date
+    if(state.query.createdDate?.thru) {
+      params["createdDate_thru"] = convertIsoToMillis(state.query.createdDate.thru)
+    }
+    // created after date
+    if(state.query.createdDate?.from) {
+      params["createdDate_from"] = convertIsoToMillis(state.query.createdDate.from)
     }
 
-    if(state.query.closedDate) {
-      // closed before date
-      if(state.query.closedDate?.thru) {
-        params["closedDate_thru"] = convertIsoToMillis(state.query.closedDate.thru)
-      }
-      // closed after date
-      if(state.query.closedDate?.from) {
-        params["closedDate_from"] = convertIsoToMillis(state.query.closedDate.from)
-      }
+    // closed before date
+    if(state.query.closedDate?.thru) {
+      params["closedDate_thru"] = convertIsoToMillis(state.query.closedDate.thru)
+    }
+    // closed after date
+    if(state.query.closedDate?.from) {
+      params["closedDate_from"] = convertIsoToMillis(state.query.closedDate.from)
     }
 
     try {

--- a/src/store/modules/count/actions.ts
+++ b/src/store/modules/count/actions.ts
@@ -41,21 +41,22 @@ const actions: ActionTree<CountState, RootState> = {
     if(state.query.sortBy) {
       params["orderByField"] = state.query.sortBy
     }
-    // created before date
-    if (state.query.dateFilter.closedDate_thru) {
-      params["closedDate_thru"] = convertIsoToMillis(state.query.dateFilter.closedDate_thru, "thru");
-    }
+
     // created after date
-    if (state.query.dateFilter.createdDate_from) {
-      params["createdDate_from"] = convertIsoToMillis(state.query.dateFilter.createdDate_from, "from");
+    if(state.query.createdDate_from) {
+      params["createdDate_from"] = convertIsoToMillis(state.query.createdDate_from, "from");
     }
-    // closed before date
-    if (state.query.dateFilter.closedDate_thru) {
-      params["closedDate_thru"] = convertIsoToMillis(state.query.dateFilter.closedDate_thru, "thru");
+    // created before date
+    if(state.query.createdDate_thru) {
+      params["createdDate_thru"] = convertIsoToMillis(state.query.createdDate_thru, "thru");
     }
     // closed after date
-    if (state.query.dateFilter.closedDate_from) {
-      params["closedDate_from"] = convertIsoToMillis(state.query.dateFilter.closedDate_from, "from");
+    if(state.query.closedDate_from) {
+      params["closedDate_from"] = convertIsoToMillis(state.query.closedDate_from, "from");
+    }
+    // closed before date
+    if(state.query.closedDate_thru) {
+      params["closedDate_thru"] = convertIsoToMillis(state.query.closedDate_thru, "thru");
     }
 
     try {

--- a/src/store/modules/count/actions.ts
+++ b/src/store/modules/count/actions.ts
@@ -41,23 +41,21 @@ const actions: ActionTree<CountState, RootState> = {
     if(state.query.sortBy) {
       params["orderByField"] = state.query.sortBy
     }
-
     // created before date
-    if(state.query.createdDate?.thru) {
-      params["createdDate_thru"] = convertIsoToMillis(state.query.createdDate.thru)
+    if (state.query.dateFilter.closedDate_thru) {
+      params["closedDate_thru"] = convertIsoToMillis(state.query.dateFilter.closedDate_thru, "thru");
     }
     // created after date
-    if(state.query.createdDate?.from) {
-      params["createdDate_from"] = convertIsoToMillis(state.query.createdDate.from)
+    if (state.query.dateFilter.createdDate_from) {
+      params["createdDate_from"] = convertIsoToMillis(state.query.dateFilter.createdDate_from, "from");
     }
-
     // closed before date
-    if(state.query.closedDate?.thru) {
-      params["closedDate_thru"] = convertIsoToMillis(state.query.closedDate.thru)
+    if (state.query.dateFilter.closedDate_thru) {
+      params["closedDate_thru"] = convertIsoToMillis(state.query.dateFilter.closedDate_thru, "thru");
     }
     // closed after date
-    if(state.query.closedDate?.from) {
-      params["closedDate_from"] = convertIsoToMillis(state.query.closedDate.from)
+    if (state.query.dateFilter.closedDate_from) {
+      params["closedDate_from"] = convertIsoToMillis(state.query.dateFilter.closedDate_from, "from");
     }
 
     try {

--- a/src/store/modules/count/actions.ts
+++ b/src/store/modules/count/actions.ts
@@ -3,7 +3,7 @@ import RootState from "@/store/RootState"
 import CountState from "./CountState"
 import * as types from "./mutation-types"
 import { CountService } from "@/services/CountService"
-import { hasError, showToast, sortListByField } from "@/utils"
+import { convertIsoToMillis, hasError, showToast, sortListByField } from "@/utils"
 import { translate } from "@/i18n"
 import router from "@/router"
 import logger from "@/logger";
@@ -45,23 +45,23 @@ const actions: ActionTree<CountState, RootState> = {
     if(state.query.createdDate) {
       // created before date
       if(state.query.createdDate?.thru) {
-        params["createdDate_thru"] = state.query.createdDate?.thru
+        params["createdDate_thru"] = convertIsoToMillis(state.query.createdDate.thru)
       }
       // created after date
       if(state.query.createdDate?.from) {
-        params["createdDate_from"] = state.query.createdDate?.from
-      } 
+        params["createdDate_from"] = convertIsoToMillis(state.query.createdDate.from)
+      }
     }
 
     if(state.query.closedDate) {
       // closed before date
       if(state.query.closedDate?.thru) {
-        params["closedDate_thru"] = state.query.closedDate?.thru
+        params["closedDate_thru"] = convertIsoToMillis(state.query.closedDate.thru)
       }
       // closed after date
       if(state.query.closedDate?.from) {
-        params["closedDate_from"] = state.query.closedDate?.from
-      } 
+        params["closedDate_from"] = convertIsoToMillis(state.query.closedDate.from)
+      }
     }
 
     try {

--- a/src/store/modules/count/index.ts
+++ b/src/store/modules/count/index.ts
@@ -16,7 +16,10 @@ const countModule: Module<CountState, RootState> = {
       noFacility: false,
       queryString: '',
       sortBy: 'dueDate desc',
-      dateFilter: {}
+      createdDate_from: '',
+      createdDate_thru: '',
+      closedDate_from: '',
+      closedDate_thru: ''
     },
     stats: {},
     cycleCountImportSystemMessages:[],

--- a/src/store/modules/count/index.ts
+++ b/src/store/modules/count/index.ts
@@ -15,7 +15,9 @@ const countModule: Module<CountState, RootState> = {
       facilityIds: [],
       noFacility: false,
       queryString: '',
-      sortBy: 'dueDate desc'
+      sortBy: 'dueDate desc',
+      createdDate: {},
+      closedDate: {}
     },
     stats: {},
     cycleCountImportSystemMessages:[],

--- a/src/store/modules/count/index.ts
+++ b/src/store/modules/count/index.ts
@@ -16,8 +16,7 @@ const countModule: Module<CountState, RootState> = {
       noFacility: false,
       queryString: '',
       sortBy: 'dueDate desc',
-      createdDate: {},
-      closedDate: {}
+      dateFilter: {}
     },
     stats: {},
     cycleCountImportSystemMessages:[],

--- a/src/store/modules/count/mutations.ts
+++ b/src/store/modules/count/mutations.ts
@@ -16,7 +16,9 @@ const mutations: MutationTree <CountState> = {
       facilityIds: [],
       noFacility: false,
       queryString: '',
-      sortBy: 'dueDate desc'
+      sortBy: 'dueDate desc',
+      createdDate: {},
+      closedDate: {}
     }
   },
   [types.COUNT_STATS_UPDATED](state, payload) {

--- a/src/store/modules/count/mutations.ts
+++ b/src/store/modules/count/mutations.ts
@@ -17,8 +17,7 @@ const mutations: MutationTree <CountState> = {
       noFacility: false,
       queryString: '',
       sortBy: 'dueDate desc',
-      createdDate: {},
-      closedDate: {}
+      dateFilter: {}
     }
   },
   [types.COUNT_STATS_UPDATED](state, payload) {

--- a/src/store/modules/count/mutations.ts
+++ b/src/store/modules/count/mutations.ts
@@ -17,7 +17,10 @@ const mutations: MutationTree <CountState> = {
       noFacility: false,
       queryString: '',
       sortBy: 'dueDate desc',
-      dateFilter: {}
+      createdDate_from: '',
+      createdDate_thru: '',
+      closedDate_from: '',
+      closedDate_thru: ''
     }
   },
   [types.COUNT_STATS_UPDATED](state, payload) {

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -55,8 +55,8 @@ const getDateTime = (time: any) => {
   return time ? DateTime.fromMillis(time).toISO() : ''
 }
 
-function convertIsoToMillis(isoDate: any) {
-  return DateTime.fromISO(isoDate).toMillis();
+function convertIsoToMillis(isoDate: any, timezone?: string) {
+  return timezone === "from" ? DateTime.fromISO(isoDate, {setZone: true}).startOf("day").toMillis() : DateTime.fromISO(isoDate, {setZone: true}).endOf("day").toMillis()
 }
 
 const getDerivedStatusForCount = (count: any) => {

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -56,8 +56,8 @@ const getDateTime = (time: any) => {
 }
 
 // Converts ISO date to milliseconds at start or end of day, considering timezone
-function convertIsoToMillis(isoDate: any, timezone?: string) {
-  return timezone === "from" ? DateTime.fromISO(isoDate, {setZone: true}).startOf("day").toMillis() : DateTime.fromISO(isoDate, {setZone: true}).endOf("day").toMillis()
+function convertIsoToMillis(isoDate: any, rangeSuffix?: string) {
+  return rangeSuffix === "from" ? DateTime.fromISO(isoDate, {setZone: true}).startOf("day").toMillis() : DateTime.fromISO(isoDate, {setZone: true}).endOf("day").toMillis()
 }
 
 const getDerivedStatusForCount = (count: any) => {

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -55,6 +55,7 @@ const getDateTime = (time: any) => {
   return time ? DateTime.fromMillis(time).toISO() : ''
 }
 
+// Converts ISO date to milliseconds at start or end of day, considering timezone
 function convertIsoToMillis(isoDate: any, timezone?: string) {
   return timezone === "from" ? DateTime.fromISO(isoDate, {setZone: true}).startOf("day").toMillis() : DateTime.fromISO(isoDate, {setZone: true}).endOf("day").toMillis()
 }

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -55,6 +55,10 @@ const getDateTime = (time: any) => {
   return time ? DateTime.fromMillis(time).toISO() : ''
 }
 
+function convertIsoToMillis(isoDate: any) {
+  return DateTime.fromISO(isoDate).toMillis();
+}
+
 const getDerivedStatusForCount = (count: any) => {
   const countStats = cycleCountStats(count.inventoryCountImportId)
 
@@ -178,4 +182,4 @@ function sortListByField(list: any, field = "parentProductName") {
   });
 }
 
-export { downloadCsv, jsonToCsv, showToast, hasError, handleDateTimeInput, getCycleCountStats, getDateTime, getDateWithOrdinalSuffix, getDerivedStatusForCount, getFacilityName, getPartyName, getProductIdentificationValue, timeFromNow, parseCsv, sortListByField }
+export { convertIsoToMillis, downloadCsv, jsonToCsv, showToast, hasError, handleDateTimeInput, getCycleCountStats, getDateTime, getDateWithOrdinalSuffix, getDerivedStatusForCount, getFacilityName, getPartyName, getProductIdentificationValue, timeFromNow, parseCsv, sortListByField }


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#619 

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
- Added Date range filter for cycle counts on the closed page.
- The filter can be applied to the created date and closed date of the cycle counts, with additional checks for dates before and after the created and closed dates.
### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->
![Screenshot from 2025-01-20 19-08-51](https://github.com/user-attachments/assets/805ce8b5-075a-46bf-bdc2-c1ad9fc07ace)
![Screenshot from 2025-01-20 19-08-41](https://github.com/user-attachments/assets/1898fe94-d027-4e78-9047-fb5f072a45f3)

### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I have read and followed [contribution rules](https://github.com/hotwax/inventory-count#contribution-guideline)
