### PR TITLE
Fixed: items already counted with 0 qty not visible counted (#633)

### DIFF
--- a/src/views/HardCountDetail.vue
+++ b/src/views/HardCountDetail.vue
@@ -85,7 +85,7 @@
                 </ion-button>
               </ion-item>
 
-              <ion-list v-if="currentProduct.quantity || currentProduct.scannedCount">
+              <ion-list v-if="currentProduct.quantity || currentProduct.scannedCount || currentProduct.quantity === 0 || currentProduct.scannedCount === 0">
                 <ion-item v-if="!['INV_COUNT_REJECTED', 'INV_COUNT_COMPLETED'].includes(currentProduct.itemStatusId)">
                   <ion-input :label="translate('Count')" :disabled="productStoreSettings['forceScan']" :placeholder="translate('submit physical count')" name="value" v-model="inputCount" id="value" type="number" min="0" required @keydown="inputCountValidation"/>
                 </ion-item>


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#633

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
Resolved the issue where items with a counted quantity of 0 were not visible in the counted list.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I have read and followed [contribution rules](https://github.com/hotwax/inventory-count#contribution-guideline)
