### PR TITLE
Improved: Added a check to show a toast when no facility is associated with the user (#669)

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -176,6 +176,7 @@
   "No data found": "No data found",
   "No facility found.": "No facility found.",
   "No facility group found.": "No facility group found.",
+  "No facility is associated with this user": "No facility is associated with this user",
   "No items found": "No items found",
   "No items added to count": "No items added to count",
   "No new file upload. Please try again.": "No new file upload. Please try again.",

--- a/src/views/Count.vue
+++ b/src/views/Count.vue
@@ -183,7 +183,6 @@ const cycleCount = computed(() => store.getters["count/getCycleCountsList"]);
 const isScrollable = computed(() => store.getters["count/isCycleCountScrollable"])
 const currentFacility = computed(() => store.getters["user/getCurrentFacility"])
 const cycleCountStats = computed(() => (id) => store.getters["count/getCycleCountStats"](id))
-const facilities = computed(() => store.getters["user/getFacilities"])
 
 const selectedSegment = ref("assigned");
 const isScrollingEnabled = ref(false);
@@ -225,7 +224,7 @@ async function loadMoreCycleCount(event) {
 }
 
 async function fetchCycleCounts(vSize, vIndex) {
-  if(!facilities.value.length) {
+  if(!currentFacility.value.length) {
     showToast(translate("No facility is associated with this user"));
     return;
   }

--- a/src/views/Count.vue
+++ b/src/views/Count.vue
@@ -224,7 +224,7 @@ async function loadMoreCycleCount(event) {
 }
 
 async function fetchCycleCounts(vSize, vIndex) {
-  if(!currentFacility.value.length) {
+  if(!currentFacility.value?.facilityId) {
     showToast(translate("No facility is associated with this user"));
     return;
   }

--- a/src/views/Count.vue
+++ b/src/views/Count.vue
@@ -174,7 +174,7 @@ import { translate } from '@/i18n';
 import { computed, ref } from "vue";
 import { useStore } from 'vuex';
 import { useRouter } from 'vue-router'
-import { getCycleCountStats, getDateWithOrdinalSuffix } from "@/utils"
+import { getCycleCountStats, getDateWithOrdinalSuffix, showToast } from "@/utils"
 
 const store = useStore();
 const router = useRouter()
@@ -183,6 +183,7 @@ const cycleCount = computed(() => store.getters["count/getCycleCountsList"]);
 const isScrollable = computed(() => store.getters["count/isCycleCountScrollable"])
 const currentFacility = computed(() => store.getters["user/getCurrentFacility"])
 const cycleCountStats = computed(() => (id) => store.getters["count/getCycleCountStats"](id))
+const facilities = computed(() => store.getters["user/getFacilities"])
 
 const selectedSegment = ref("assigned");
 const isScrollingEnabled = ref(false);
@@ -224,6 +225,10 @@ async function loadMoreCycleCount(event) {
 }
 
 async function fetchCycleCounts(vSize, vIndex) {
+  if(!facilities.value.length) {
+    showToast(translate("No facility is associated with this user"));
+    return;
+  }
   const pageSize = vSize ? vSize : process.env.VUE_APP_VIEW_SIZE;
   const pageIndex = vIndex ? vIndex : 0;
   const facilityId = currentFacility.value?.facilityId


### PR DESCRIPTION

### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#669 

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
- When no current facility is associated with the user, logging in on the store view page will now trigger a check to prevent fetching cycle counts and display a relevant toast message.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->
![image](https://github.com/user-attachments/assets/87774681-c9a0-4680-9d06-9df979189281)


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I have read and followed [contribution rules](https://github.com/hotwax/inventory-count#contribution-guideline)
