### PR TITLE
Fixed: Secondary Product Identifier of First Product Appears in Bold Color on Store View Screen.(#468)

### DIFF
--- a/src/views/ProductItemList.vue
+++ b/src/views/ProductItemList.vue
@@ -6,7 +6,7 @@
     <ion-label class="ion-text-wrap" v-if="item.productId">
       <p class="overline">{{ item.itemStatusId === 'INV_COUNT_REJECTED' ? "rejected" : "" }}</p>
       <h2>{{ getProductIdentificationValue(productStoreSettings["productIdentificationPref"].primaryId, getProduct(item.productId)) || getProduct(item.productId).productName }}</h2>
-      <p>{{ getProductIdentificationValue(productStoreSettings["productIdentificationPref"].secondaryId, getProduct(item.productId)) }}</p>
+      <p class="secondary-identifier">{{ getProductIdentificationValue(productStoreSettings["productIdentificationPref"].secondaryId, getProduct(item.productId)) }}</p>
     </ion-label>
     <ion-label class="ion-text-wrap" v-else>
       <h2>{{ item.scannedId }}</h2>
@@ -114,5 +114,9 @@ ion-note {
 /* Using important as we have styling that overrides this, need to update the actual styling for this */
 .overline {
   color: var(--ion-color-danger) !important;
+}
+
+.secondary-identifier {
+  color: #666666 !important;
 }
 </style>

--- a/src/views/ProductItemList.vue
+++ b/src/views/ProductItemList.vue
@@ -117,6 +117,6 @@ ion-note {
 }
 
 .secondary-identifier {
-  color: #666666 !important;
+  color: var(--ion-color-medium-shade) !important;
 }
 </style>

--- a/src/views/ProductItemList.vue
+++ b/src/views/ProductItemList.vue
@@ -6,7 +6,7 @@
     <ion-label class="ion-text-wrap" v-if="item.productId">
       <p class="overline">{{ item.itemStatusId === 'INV_COUNT_REJECTED' ? "rejected" : "" }}</p>
       <h2>{{ getProductIdentificationValue(productStoreSettings["productIdentificationPref"].primaryId, getProduct(item.productId)) || getProduct(item.productId).productName }}</h2>
-      <p class="secondary-identifier">{{ getProductIdentificationValue(productStoreSettings["productIdentificationPref"].secondaryId, getProduct(item.productId)) }}</p>
+      <p>{{ getProductIdentificationValue(productStoreSettings["productIdentificationPref"].secondaryId, getProduct(item.productId)) }}</p>
     </ion-label>
     <ion-label class="ion-text-wrap" v-else>
       <h2>{{ item.scannedId }}</h2>
@@ -114,9 +114,5 @@ ion-note {
 /* Using important as we have styling that overrides this, need to update the actual styling for this */
 .overline {
   color: var(--ion-color-danger) !important;
-}
-
-.secondary-identifier {
-  color: var(--ion-color-medium-shade) !important;
 }
 </style>

--- a/src/views/ProductItemList.vue
+++ b/src/views/ProductItemList.vue
@@ -1,5 +1,5 @@
 <template>
-  <ion-item v-if="currentProduct" :color="isCurrentProduct() ? 'light' : ''" button @click="navigateToDetail(item)">
+  <ion-item v-if="currentProduct" :key="currentProduct.productId" :color="isCurrentProduct() ? 'light' : ''" button @click="navigateToDetail(item)">
     <ion-thumbnail slot="start">
       <Image :src="getProduct(item.productId).mainImageUrl"/>
     </ion-thumbnail>


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->
#468 
#

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->


### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->
![image](https://github.com/user-attachments/assets/8a73775b-8e94-4e34-a9cd-13319d0d4a89)


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I have read and followed [contribution rules](https://github.com/hotwax/inventory-count#contribution-guideline)
