### PR TITLE
Fixed: User is now able to rename the unnamed cycle count (#689)

### DIFF
--- a/src/views/DraftDetail.vue
+++ b/src/views/DraftDetail.vue
@@ -364,7 +364,7 @@ async function updateCountName() {
     return;
   }
 
-  if(countName.value.trim() !== currentCycleCount.value.countName.trim()) {
+  if(countName.value.trim() !== currentCycleCount.value.countName?.trim()) {
     await CountService.updateCycleCount({ inventoryCountImportId: currentCycleCount.value.countId, countImportName: countName.value.trim() })
     .then(() => {
       currentCycleCount.value.countName = countName.value.trim()

--- a/src/views/PendingReviewDetail.vue
+++ b/src/views/PendingReviewDetail.vue
@@ -350,7 +350,7 @@ async function updateCountName() {
     return;
   }
 
-  if(countName.value.trim() !== currentCycleCount.value.countName.trim()) {
+  if(countName.value.trim() !== currentCycleCount.value.countName?.trim()) {
     await CountService.updateCycleCount({ inventoryCountImportId: currentCycleCount.value.countId, countImportName: countName.value.trim() })
     .then(() => {
       currentCycleCount.value.countName = countName.value.trim()


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#689 

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
- The count that was created without a cycle count name or if the cycle count name does not exist can now be updated by the user

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I have read and followed [contribution rules](https://github.com/hotwax/inventory-count#contribution-guideline)
