### PR TITLE
Improved: Added barcode identifier on the store view's settings page(#584)

### DIFF
--- a/src/components/ForceScanCard.vue
+++ b/src/components/ForceScanCard.vue
@@ -1,0 +1,55 @@
+<template>
+  <ion-card>
+    <ion-card-header>
+      <ion-card-title>
+        {{ translate('Force scan') }}
+      </ion-card-title>
+    </ion-card-header>
+    <ion-card-content v-html="barcodeContentMessage"></ion-card-content>
+    <ion-item lines="none" :disabled="!hasPermission('APP_DRAFT_VIEW')">
+      <ion-toggle :checked="productStoreSettings['forceScan']" @click.prevent="updateProductStoreSetting($event, 'forceScan')">
+        {{ translate("Require barcode scanning") }}
+      </ion-toggle>
+    </ion-item>
+    <ion-item lines="none" :disabled="!hasPermission('APP_DRAFT_VIEW')">
+      <ion-select :label="translate('Barcode Identifier')" interface="popover" :placeholder="translate('Select')" :value="productStoreSettings['barcodeIdentificationPref']" @ionChange="setBarcodeIdentificationPref($event.detail.value)">
+        <ion-select-option v-for="identification in productIdentifications" :key="identification" :value="identification" >{{ identification }}</ion-select-option>
+      </ion-select>
+    </ion-item>
+  </ion-card>
+</template>
+
+<script setup lang="ts">
+import {
+  IonCard,
+  IonCardContent,
+  IonCardHeader,
+  IonCardTitle,
+  IonItem,
+  IonSelect,
+  IonSelectOption,
+  IonToggle
+} from "@ionic/vue";
+import { translate } from '@/i18n'
+import store from "@/store";
+import { computed, onMounted, ref } from "vue";
+import { hasPermission } from "@/authorization"
+
+const barcodeContentMessage = translate("Require inventory to be scanned when counting instead of manually entering values. If the identifier is not found, the scan will default to using the internal name.", { space: '<br /><br />' })
+const productStoreSettings = computed(() => store.getters["user/getProductStoreSettings"])
+const productIdentifications = computed(() => store.getters["user/getGoodIdentificationTypes"])
+
+function updateProductStoreSetting(event: any, key: string) {
+  event.stopImmediatePropagation();
+  store.dispatch("user/setProductStoreSetting", { key, value: !productStoreSettings.value[key] })
+}
+
+function setBarcodeIdentificationPref(value: any) {
+  store.dispatch("user/setProductStoreSetting", { key: "barcodeIdentificationPref", value })
+}
+
+onMounted(async () => {
+  await store.dispatch("user/getProductStoreSetting")
+  await store.dispatch("user/fetchGoodIdentificationTypes")
+})
+</script>

--- a/src/views/Settings.vue
+++ b/src/views/Settings.vue
@@ -132,6 +132,8 @@
             </ion-select>
           </ion-item>
         </ion-card>
+        <!-- render the ForceScanCard component only if the current route path includes '/tabs/'(Store view) -->
+        <ForceScanCard v-if="router.currentRoute.value.fullPath.includes('/tabs/')"/>
 
         <ion-card>
           <ion-card-header>
@@ -164,6 +166,7 @@ import { goToOms } from "@hotwax/dxp-components";
 import { Actions, hasPermission } from "@/authorization"
 import router from "@/router";
 import { DateTime } from "luxon";
+import ForceScanCard from "@/components/ForceScanCard.vue";
 
 const store = useStore()
 const appVersion = ref("")

--- a/src/views/StorePermissions.vue
+++ b/src/views/StorePermissions.vue
@@ -23,24 +23,7 @@
             </ion-toggle>
           </ion-item>
         </ion-card>
-        <ion-card>
-          <ion-card-header>
-            <ion-card-title>
-              {{ translate('Force scan') }}
-            </ion-card-title>
-          </ion-card-header>
-          <ion-card-content v-html="barcodeContentMessage"></ion-card-content>
-          <ion-item lines="none">
-            <ion-toggle :checked="productStoreSettings['forceScan']" @click.prevent="updateProductStoreSetting($event, 'forceScan')">
-              {{ translate("Require barcode scanning") }}
-            </ion-toggle>
-          </ion-item>
-          <ion-item lines="none">
-            <ion-select :label="translate('Barcode Identifier')" interface="popover" :placeholder="translate('Select')" :value="productStoreSettings['barcodeIdentificationPref']" @ionChange="setBarcodeIdentificationPref($event.detail.value)">
-              <ion-select-option v-for="identification in productIdentifications" :key="identification" :value="identification" >{{ identification }}</ion-select-option>
-            </ion-select>
-          </ion-item>
-        </ion-card>
+        <ForceScanCard />
       </div>
     </ion-content> 
   </ion-page>
@@ -56,8 +39,6 @@ import {
   IonHeader,
   IonItem,
   IonPage,
-  IonSelect,
-  IonSelectOption,
   IonTitle,
   IonToggle,
   IonToolbar,
@@ -66,23 +47,17 @@ import {
 import { translate } from '@/i18n'
 import store from "@/store";
 import { computed } from "vue";
+import ForceScanCard from "@/components/ForceScanCard.vue";
 
-const barcodeContentMessage = translate("Require inventory to be scanned when counting instead of manually entering values. If the identifier is not found, the scan will default to using the internal name.", { space: '<br /><br />' })
 const productStoreSettings = computed(() => store.getters["user/getProductStoreSettings"])
-const productIdentifications = computed(() => store.getters["user/getGoodIdentificationTypes"])
 
 onIonViewWillEnter(async () => {
   await store.dispatch("user/getProductStoreSetting")
-  await store.dispatch("user/fetchGoodIdentificationTypes")
 })
 
 function updateProductStoreSetting(event: any, key: string) {
   event.stopImmediatePropagation();
   store.dispatch("user/setProductStoreSetting", { key, value: !productStoreSettings.value[key] })
-}
-
-function setBarcodeIdentificationPref(value: any) {
-  store.dispatch("user/setProductStoreSetting", { key: "barcodeIdentificationPref", value })
 }
 </script>
 


### PR DESCRIPTION

### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#584 

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
- Added a separate component for the Force Scan card and used it on the Store Permissions and Settings page of the Store View.  
- Added a Barcode Identification card on the Settings page of the Store View.  
- The card will be disabled if the user does not have the `APP_DRAFT_VIEW` permission.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->
![image](https://github.com/user-attachments/assets/d111658e-24c0-43a4-b3d6-74d644b30982)


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I have read and followed [contribution rules](https://github.com/hotwax/inventory-count#contribution-guideline)
