### PR TITLE
Improved: Selected facility name is consistent across all pages in Filters (#586)

### DIFF
--- a/src/components/Filters.vue
+++ b/src/components/Filters.vue
@@ -32,17 +32,15 @@
           </ion-select>
         </ion-item>
 
-        <template v-if="showAdditionalFilters().selectedFacilities">
-          <ion-item v-for="facilityId in query.facilityIds" :key="facilityId">
-            <ion-label>{{ getFacilityName(facilityId) }}</ion-label>
-            <ion-button color="danger" v-if="query.facilityIds.length" fill="clear" slot="end" @click="updateQuery('facilityIds', query.facilityIds.filter((id: string) => id !== facilityId))">
-              <ion-icon slot="icon-only" :icon="closeCircleOutline"/>
-            </ion-button>
-          </ion-item>
-          <ion-item v-show="!query.facilityIds.length">
-            <ion-label>{{ translate("All facilities selected") }}</ion-label>
-          </ion-item>
-        </template>
+        <ion-item v-for="facilityId in query.facilityIds" :key="facilityId">
+          <ion-label>{{ getFacilityName(facilityId) }}</ion-label>
+          <ion-button color="danger" v-if="query.facilityIds.length" fill="clear" slot="end" @click="updateQuery('facilityIds', query.facilityIds.filter((id: string) => id !== facilityId))">
+            <ion-icon slot="icon-only" :icon="closeCircleOutline"/>
+          </ion-button>
+        </ion-item>
+        <ion-item v-show="!query.facilityIds.length">
+          <ion-label>{{ translate("All facilities selected") }}</ion-label>
+        </ion-item>
 
         <ion-item-divider v-if="showAdditionalFilters().date">
           <ion-label>{{ translate("Date") }}</ion-label>
@@ -198,7 +196,6 @@ function formatDateTime(date: any) {
 function showAdditionalFilters() {
   return {
     noFacility: router.currentRoute.value.name === "Draft",
-    selectedFacilities: router.currentRoute.value.name === "Closed",
     date: router.currentRoute.value.name !== "Draft"
   }
 }


### PR DESCRIPTION

### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#586 

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
- Removed the restriction of displaying selected facilities only in the Filters on the Closed page.  
- The selected facility is now visible across all pages, including Draft, Assigned, and Pending Review, within the Filter.
### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->
![image](https://github.com/user-attachments/assets/2a202780-5e80-4edd-bd13-83fe31ad28d1)
![image](https://github.com/user-attachments/assets/c916672f-8d45-4fcd-a651-2f0338bb4cda)
![image](https://github.com/user-attachments/assets/421a1921-e6ac-447a-a32c-3683ab0adad8)


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I have read and followed [contribution rules](https://github.com/hotwax/inventory-count#contribution-guideline)
