### PR TITLE
Implemented: Added a Sort By filter for Created Date, Due Date, and Alphabetical sorting on the Draft, Assigned, Pending review and closed page(#631)

### DIFF
--- a/src/components/Filters.vue
+++ b/src/components/Filters.vue
@@ -22,16 +22,6 @@
           <ion-checkbox v-model="query.noFacility" :disabled="query.facilityIds?.length" @ionChange="updateQuery('noFacility', $event.detail.checked)">{{ translate("No facility") }}</ion-checkbox>
         </ion-item>
 
-        <ion-item lines="none">
-          <ion-icon slot="start" :icon="swapVerticalOutline" />
-          <ion-select :label="translate('Sort by')" :value="query.sortBy" @ionChange="updateQuery('sortBy', $event.detail.value)" interface="popover">
-            <ion-select-option value="dueDate desc">{{ translate("Farthest due") }}</ion-select-option>
-            <ion-select-option value="dueDate asc">{{ translate("Nearest due") }}</ion-select-option>
-            <ion-select-option value="countImportName asc">{{ translate("Name - A to Z") }}</ion-select-option>
-            <ion-select-option value="countImportName desc">{{ translate("Name - Z to A") }}</ion-select-option>
-          </ion-select>
-        </ion-item>
-
         <ion-item v-for="facilityId in query.facilityIds" :key="facilityId">
           <ion-label>{{ getFacilityName(facilityId) }}</ion-label>
           <ion-button color="danger" v-if="query.facilityIds.length" fill="clear" slot="end" @click="updateQuery('facilityIds', query.facilityIds.filter((id: string) => id !== facilityId))">
@@ -120,7 +110,7 @@ import {
   IonToolbar
 } from "@ionic/vue";
 import { computed, ref } from "vue";
-import { closeCircleOutline, businessOutline, gitBranchOutline, gitPullRequestOutline, locateOutline, swapVerticalOutline } from "ionicons/icons";
+import { closeCircleOutline, businessOutline, gitBranchOutline, gitPullRequestOutline, locateOutline } from "ionicons/icons";
 import { translate } from '@/i18n'
 import store from "@/store";
 import router from "@/router";

--- a/src/components/SearchBarAndSortBy.vue
+++ b/src/components/SearchBarAndSortBy.vue
@@ -11,7 +11,7 @@
 </template>
 
 <script setup lang="ts">
-import { IonContent, IonIcon, IonItem, IonSearchbar, IonSelect, IonSelectOption } from "@ionic/vue";
+import { IonIcon, IonItem, IonSearchbar, IonSelect, IonSelectOption } from "@ionic/vue";
 import { swapVerticalOutline } from "ionicons/icons";
 import { computed, defineEmits } from "vue"
 import { translate } from "@/i18n";

--- a/src/components/SearchBarAndSortBy.vue
+++ b/src/components/SearchBarAndSortBy.vue
@@ -4,8 +4,8 @@
     <ion-item lines="none">
       <ion-icon slot="start" :icon="swapVerticalOutline" />
       <ion-select :label="translate('Sort by')" :value="query.sortBy" @ionChange="updateQuery('sortBy', $event.detail.value)" interface="popover">
-        <ion-select-option value="dueDate desc">{{ translate("Due date") }}</ion-select-option>
-        <ion-select-option value="createdDate desc">{{ translate("Created date") }}</ion-select-option>
+        <ion-select-option value="dueDate asc">{{ translate("Due date") }}</ion-select-option>
+        <ion-select-option value="createdDate asc">{{ translate("Created date") }}</ion-select-option>
         <ion-select-option value="countImportName asc">{{ translate("Alphabetic") }}</ion-select-option>
       </ion-select> 
     </ion-item>

--- a/src/components/SearchBarAndSortBy.vue
+++ b/src/components/SearchBarAndSortBy.vue
@@ -1,13 +1,15 @@
 <template>
-  <ion-searchbar v-model="query.queryString" @keyup.enter="updateQuery('queryString', $event.target.value)" />
-  <ion-item lines="none">
-    <ion-icon slot="start" :icon="swapVerticalOutline" />
-    <ion-select :label="translate('Sort by')" :value="query.sortBy" @ionChange="updateQuery('sortBy', $event.detail.value)" interface="popover">
-      <ion-select-option value="dueDate desc">{{ translate("Due date") }}</ion-select-option>
-      <ion-select-option value="createdDate desc">{{ translate("Created date") }}</ion-select-option>
-      <ion-select-option value="countImportName asc">{{ translate("Alphabetic") }}</ion-select-option>
-    </ion-select> 
-  </ion-item>
+  <div class="header searchbar">
+    <ion-searchbar v-model="query.queryString" @keyup.enter="updateQuery('queryString', $event.target.value)" />
+    <ion-item lines="none">
+      <ion-icon slot="start" :icon="swapVerticalOutline" />
+      <ion-select :label="translate('Sort by')" :value="query.sortBy" @ionChange="updateQuery('sortBy', $event.detail.value)" interface="popover">
+        <ion-select-option value="dueDate desc">{{ translate("Due date") }}</ion-select-option>
+        <ion-select-option value="createdDate desc">{{ translate("Created date") }}</ion-select-option>
+        <ion-select-option value="countImportName asc">{{ translate("Alphabetic") }}</ion-select-option>
+      </ion-select> 
+    </ion-item>
+  </div>
 </template>
 
 <script setup lang="ts">

--- a/src/components/SearchBarAndSortBy.vue
+++ b/src/components/SearchBarAndSortBy.vue
@@ -3,8 +3,8 @@
   <ion-item lines="none">
     <ion-icon slot="start" :icon="swapVerticalOutline" />
     <ion-select :label="translate('Sort by')" :value="query.sortBy" @ionChange="updateQuery('sortBy', $event.detail.value)" interface="popover">
-      <ion-select-option value="createdDate desc">{{ translate("Created date") }}</ion-select-option>
       <ion-select-option value="dueDate desc">{{ translate("Due date") }}</ion-select-option>
+      <ion-select-option value="createdDate desc">{{ translate("Created date") }}</ion-select-option>
       <ion-select-option value="countImportName asc">{{ translate("Alphabetic") }}</ion-select-option>
     </ion-select> 
   </ion-item>
@@ -13,18 +13,17 @@
 <script setup lang="ts">
 import { IonContent, IonIcon, IonItem, IonSearchbar, IonSelect, IonSelectOption } from "@ionic/vue";
 import { swapVerticalOutline } from "ionicons/icons";
-import { computed } from "vue"
+import { computed, defineEmits } from "vue"
 import { translate } from "@/i18n";
-import { defineEmits } from "vue";
 import store from "@/store";
 
-const emit = defineEmits(['emitUpdateQueryString'])
+const emit = defineEmits(['queryStringUpdated'])
 
 const query = computed(() => store.getters["count/getQuery"])
 
 async function updateQueryString(key: string, value: any) {
   await store.dispatch("count/updateQueryString", { key, value })
-  emit('emitUpdateQueryString')
+  emit('queryStringUpdated')
 }
 
 async function updateQuery(key: string, value: any) {

--- a/src/components/SearchBarAndSortBy.vue
+++ b/src/components/SearchBarAndSortBy.vue
@@ -1,0 +1,33 @@
+<template>
+  <ion-searchbar v-model="query.queryString" @keyup.enter="updateQueryString('queryString', $event.target.value)" />
+  <ion-item lines="none">
+    <ion-icon slot="start" :icon="swapVerticalOutline" />
+    <ion-select :label="translate('Sort by')" :value="query.sortBy" @ionChange="updateQuery('sortBy', $event.detail.value)" interface="popover">
+      <ion-select-option value="createdDate desc">{{ translate("Created date") }}</ion-select-option>
+      <ion-select-option value="dueDate desc">{{ translate("Due date") }}</ion-select-option>
+      <ion-select-option value="countImportName asc">{{ translate("Alphabetic") }}</ion-select-option>
+    </ion-select> 
+  </ion-item>
+</template>
+
+<script setup lang="ts">
+import { IonContent, IonIcon, IonItem, IonSearchbar, IonSelect, IonSelectOption } from "@ionic/vue";
+import { swapVerticalOutline } from "ionicons/icons";
+import { computed } from "vue"
+import { translate } from "@/i18n";
+import { defineEmits } from "vue";
+import store from "@/store";
+
+const emit = defineEmits(['emitUpdateQueryString'])
+
+const query = computed(() => store.getters["count/getQuery"])
+
+async function updateQueryString(key: string, value: any) {
+  await store.dispatch("count/updateQueryString", { key, value })
+  emit('emitUpdateQueryString')
+}
+
+async function updateQuery(key: string, value: any) {
+  await store.dispatch("count/updateQuery", { key, value })
+}
+</script>

--- a/src/components/SearchBarAndSortBy.vue
+++ b/src/components/SearchBarAndSortBy.vue
@@ -1,5 +1,5 @@
 <template>
-  <ion-searchbar v-model="query.queryString" @keyup.enter="updateQueryString('queryString', $event.target.value)" />
+  <ion-searchbar v-model="query.queryString" @keyup.enter="updateQuery('queryString', $event.target.value)" />
   <ion-item lines="none">
     <ion-icon slot="start" :icon="swapVerticalOutline" />
     <ion-select :label="translate('Sort by')" :value="query.sortBy" @ionChange="updateQuery('sortBy', $event.detail.value)" interface="popover">
@@ -13,18 +13,11 @@
 <script setup lang="ts">
 import { IonIcon, IonItem, IonSearchbar, IonSelect, IonSelectOption } from "@ionic/vue";
 import { swapVerticalOutline } from "ionicons/icons";
-import { computed, defineEmits } from "vue"
+import { computed } from "vue"
 import { translate } from "@/i18n";
 import store from "@/store";
 
-const emit = defineEmits(['queryStringUpdated'])
-
 const query = computed(() => store.getters["count/getQuery"])
-
-async function updateQueryString(key: string, value: any) {
-  await store.dispatch("count/updateQueryString", { key, value })
-  emit('queryStringUpdated')
-}
 
 async function updateQuery(key: string, value: any) {
   await store.dispatch("count/updateQuery", { key, value })

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -14,6 +14,7 @@
   "All": "All",
   "All facilities selected": "All facilities selected",
   "All of the item(s) are accepted": "All of the item(s) are accepted",
+  "Alphabetic": "Alphabetic",
   "Any edits made in the counted quantity on this page will be lost.": "Any edits made in the counted quantity on this page will be lost.",
   "App": "App",
   "Are you sure you want to change the time zone to?": "Are you sure you want to change the time zone to {timeZoneId}?",

--- a/src/store/modules/count/actions.ts
+++ b/src/store/modules/count/actions.ts
@@ -179,7 +179,7 @@ const actions: ActionTree<CountState, RootState> = {
       statusId = "INV_COUNT_COMPLETED"
     }
     dispatch("fetchCycleCounts", { pageSize: process.env.VUE_APP_VIEW_SIZE, pageIndex: 0, statusId })
-    if(payload.key === "facilityIds" && router.currentRoute.value.name === "Closed") dispatch("fetchClosedCycleCountsTotal")
+    if(payload.key === "facilityIds" && statusId === "INV_COUNT_COMPLETED") dispatch("fetchClosedCycleCountsTotal")
   },
 
   async clearQuery({ commit }) {

--- a/src/store/modules/count/actions.ts
+++ b/src/store/modules/count/actions.ts
@@ -179,11 +179,7 @@ const actions: ActionTree<CountState, RootState> = {
       statusId = "INV_COUNT_COMPLETED"
     }
     dispatch("fetchCycleCounts", { pageSize: process.env.VUE_APP_VIEW_SIZE, pageIndex: 0, statusId })
-    if(payload.key === "facilityIds") dispatch("fetchClosedCycleCountsTotal")
-  },
-
-  async updateQueryString({ commit }, payload) {
-    commit(types.COUNT_QUERY_UPDATED, payload)
+    if(payload.key === "facilityIds" && router.currentRoute.value.name === "Closed") dispatch("fetchClosedCycleCountsTotal")
   },
 
   async clearQuery({ commit }) {

--- a/src/store/modules/count/index.ts
+++ b/src/store/modules/count/index.ts
@@ -15,7 +15,7 @@ const countModule: Module<CountState, RootState> = {
       facilityIds: [],
       noFacility: false,
       queryString: '',
-      sortBy: 'dueDate desc',
+      sortBy: 'dueDate asc',
       createdDate_from: '',
       createdDate_thru: '',
       closedDate_from: '',

--- a/src/store/modules/count/index.ts
+++ b/src/store/modules/count/index.ts
@@ -15,7 +15,7 @@ const countModule: Module<CountState, RootState> = {
       facilityIds: [],
       noFacility: false,
       queryString: '',
-      sortBy: 'createdDate desc',
+      sortBy: 'dueDate desc',
       createdDate_from: '',
       createdDate_thru: '',
       closedDate_from: '',

--- a/src/store/modules/count/index.ts
+++ b/src/store/modules/count/index.ts
@@ -15,7 +15,7 @@ const countModule: Module<CountState, RootState> = {
       facilityIds: [],
       noFacility: false,
       queryString: '',
-      sortBy: 'dueDate desc',
+      sortBy: 'createdDate desc',
       createdDate_from: '',
       createdDate_thru: '',
       closedDate_from: '',

--- a/src/store/modules/count/mutations.ts
+++ b/src/store/modules/count/mutations.ts
@@ -16,7 +16,7 @@ const mutations: MutationTree <CountState> = {
       facilityIds: [],
       noFacility: false,
       queryString: '',
-      sortBy: 'dueDate desc',
+      sortBy: 'createdDate desc',
       createdDate_from: '',
       createdDate_thru: '',
       closedDate_from: '',

--- a/src/store/modules/count/mutations.ts
+++ b/src/store/modules/count/mutations.ts
@@ -16,7 +16,7 @@ const mutations: MutationTree <CountState> = {
       facilityIds: [],
       noFacility: false,
       queryString: '',
-      sortBy: 'createdDate desc',
+      sortBy: 'dueDate desc',
       createdDate_from: '',
       createdDate_thru: '',
       closedDate_from: '',

--- a/src/theme/variables.css
+++ b/src/theme/variables.css
@@ -276,11 +276,17 @@ main {
 
 .header {
   display: grid;
-  grid-template-columns: repeat(2, 1fr);
+  grid-template-columns: repeat(auto-fit, minmax(0, 1fr));
   align-items: center;
   gap: var(--spacer-xs);
 }
-    
+
+@media (max-width: 991px) {
+  .header {
+    grid-template-columns: 1fr;
+  }
+}
+
 section {
   display: grid;
   /* grid-template-columns: minmax(400px); */

--- a/src/theme/variables.css
+++ b/src/theme/variables.css
@@ -273,6 +273,13 @@ main {
   /* gap: var(--spacer-2xl); */
   max-width: 100%;
 }
+
+.header {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  align-items: center;
+  gap: var(--spacer-xs);
+}
     
 section {
   display: grid;

--- a/src/views/Assigned.vue
+++ b/src/views/Assigned.vue
@@ -62,7 +62,7 @@
 import { computed, ref } from "vue";
 import { translate } from '@/i18n'
 import { filterOutline, storefrontOutline } from "ionicons/icons";
-import { IonBadge, IonButtons, IonChip, IonContent, IonHeader, IonIcon, IonItem, IonInfiniteScroll, IonInfiniteScrollContent, IonLabel, IonList, IonMenuButton, IonPage, IonSearchbar, IonSelect, IonSelectOption, IonTitle, IonToolbar, onIonViewDidEnter, onIonViewWillLeave } from "@ionic/vue";
+import { IonBadge, IonButtons, IonChip, IonContent, IonHeader, IonIcon, IonItem, IonInfiniteScroll, IonInfiniteScrollContent, IonLabel, IonList, IonMenuButton, IonPage, IonTitle, IonToolbar, onIonViewDidEnter, onIonViewWillLeave } from "@ionic/vue";
 import store from "@/store"
 import { getCycleCountStats, getDateWithOrdinalSuffix, getDerivedStatusForCount, getFacilityName } from "@/utils"
 import Filters from "@/components/Filters.vue"
@@ -71,7 +71,6 @@ import SearchBarAndSortBy from "@/components/SearchBarAndSortBy.vue";
 
 const cycleCounts = computed(() => store.getters["count/getCounts"])
 const isScrollable = computed(() => store.getters["count/isCycleCountListScrollable"])
-const query = computed(() => store.getters["count/getQuery"])
 
 const isScrollingEnabled = ref(false);
 const contentRef = ref({}) as any
@@ -134,12 +133,5 @@ async function fetchAssignedCycleCount(vSize?: any, vIndex?: any) {
 
 .list-item > ion-item {
   width: 100%;
-}
-
-.header {
-  display: grid;
-  grid-template-columns: repeat(2, 1fr);
-  align-items: center;
-  gap: var(--spacer-xs);
 }
 </style>

--- a/src/views/Assigned.vue
+++ b/src/views/Assigned.vue
@@ -14,15 +14,7 @@
 
     <ion-content ref="contentRef" :scroll-events="true" @ionScroll="enableScrolling()" id="filter">
       <div class="header searchbar">
-        <ion-searchbar v-model="query.queryString" @keyup.enter="updateQueryString('queryString', $event.target.value)" />
-        <ion-item lines="none">
-          <ion-icon slot="start" :icon="swapVerticalOutline" />
-          <ion-select :label="translate('Sort by')" :value="query.sortBy" @ionChange="updateQuery('sortBy', $event.detail.value)" interface="popover">
-            <ion-select-option value="createdDate desc">{{ translate("Created date") }}</ion-select-option>
-            <ion-select-option value="dueDate desc">{{ translate("Due date") }}</ion-select-option>
-            <ion-select-option value="countImportName asc">{{ translate("Alphabetic") }}</ion-select-option>
-          </ion-select> 
-        </ion-item>
+        <SearchBarAndSortBy @emitUpdateQueryString="updateQueryString" />
       </div>
       <p v-if="!cycleCounts.length" class="empty-state">
         {{ translate("No cycle counts found") }}
@@ -75,6 +67,7 @@ import store from "@/store"
 import { getCycleCountStats, getDateWithOrdinalSuffix, getDerivedStatusForCount, getFacilityName } from "@/utils"
 import Filters from "@/components/Filters.vue"
 import router from "@/router"
+import SearchBarAndSortBy from "@/components/SearchBarAndSortBy.vue";
 
 const cycleCounts = computed(() => store.getters["count/getCounts"])
 const isScrollable = computed(() => store.getters["count/isCycleCountListScrollable"])
@@ -104,8 +97,7 @@ function enableScrolling() {
   }
 }
 
-async function updateQueryString(key: string, value: any) {
-  await store.dispatch("count/updateQueryString", { key, value })
+async function updateQueryString() {
   fetchAssignedCycleCount();
 }
 

--- a/src/views/Assigned.vue
+++ b/src/views/Assigned.vue
@@ -14,7 +14,7 @@
 
     <ion-content ref="contentRef" :scroll-events="true" @ionScroll="enableScrolling()" id="filter">
       <div class="header searchbar">
-        <SearchBarAndSortBy @emitUpdateQueryString="updateQueryString" />
+        <SearchBarAndSortBy @queryStringUpdated="queryStringUpdated" />
       </div>
       <p v-if="!cycleCounts.length" class="empty-state">
         {{ translate("No cycle counts found") }}
@@ -97,7 +97,7 @@ function enableScrolling() {
   }
 }
 
-async function updateQueryString() {
+async function queryStringUpdated() {
   fetchAssignedCycleCount();
 }
 

--- a/src/views/Assigned.vue
+++ b/src/views/Assigned.vue
@@ -124,10 +124,6 @@ async function fetchAssignedCycleCount(vSize?: any, vIndex?: any) {
   }
   await store.dispatch("count/fetchCycleCounts", payload)
 }
-
-async function updateQuery(key: string, value: any) {
-  await store.dispatch("count/updateQuery", { key, value })
-}
 </script>
 
 <style scoped>

--- a/src/views/Assigned.vue
+++ b/src/views/Assigned.vue
@@ -13,9 +13,7 @@
     </ion-header>
 
     <ion-content ref="contentRef" :scroll-events="true" @ionScroll="enableScrolling()" id="filter">
-      <div class="header searchbar">
-        <SearchBarAndSortBy />
-      </div>
+      <SearchBarAndSortBy />
       <p v-if="!cycleCounts.length" class="empty-state">
         {{ translate("No cycle counts found") }}
       </p>

--- a/src/views/Assigned.vue
+++ b/src/views/Assigned.vue
@@ -61,7 +61,7 @@
 <script setup lang="ts">
 import { computed, ref } from "vue";
 import { translate } from '@/i18n'
-import { filterOutline, storefrontOutline, swapVerticalOutline } from "ionicons/icons";
+import { filterOutline, storefrontOutline } from "ionicons/icons";
 import { IonBadge, IonButtons, IonChip, IonContent, IonHeader, IonIcon, IonItem, IonInfiniteScroll, IonInfiniteScrollContent, IonLabel, IonList, IonMenuButton, IonPage, IonSearchbar, IonSelect, IonSelectOption, IonTitle, IonToolbar, onIonViewDidEnter, onIonViewWillLeave } from "@ionic/vue";
 import store from "@/store"
 import { getCycleCountStats, getDateWithOrdinalSuffix, getDerivedStatusForCount, getFacilityName } from "@/utils"

--- a/src/views/Assigned.vue
+++ b/src/views/Assigned.vue
@@ -14,7 +14,7 @@
 
     <ion-content ref="contentRef" :scroll-events="true" @ionScroll="enableScrolling()" id="filter">
       <div class="header searchbar">
-        <SearchBarAndSortBy @queryStringUpdated="queryStringUpdated" />
+        <SearchBarAndSortBy />
       </div>
       <p v-if="!cycleCounts.length" class="empty-state">
         {{ translate("No cycle counts found") }}
@@ -94,10 +94,6 @@ function enableScrolling() {
   } else {
     isScrollingEnabled.value = true;
   }
-}
-
-async function queryStringUpdated() {
-  fetchAssignedCycleCount();
 }
 
 async function loadMoreCycleCounts(event: any) {

--- a/src/views/Assigned.vue
+++ b/src/views/Assigned.vue
@@ -13,7 +13,17 @@
     </ion-header>
 
     <ion-content ref="contentRef" :scroll-events="true" @ionScroll="enableScrolling()" id="filter">
-      <ion-searchbar class="searchbar" v-model="query.queryString" @keyup.enter="updateQueryString('queryString', $event.target.value)" />
+      <div class="header searchbar">
+        <ion-searchbar v-model="query.queryString" @keyup.enter="updateQueryString('queryString', $event.target.value)" />
+        <ion-item lines="none">
+          <ion-icon slot="start" :icon="swapVerticalOutline" />
+          <ion-select :label="translate('Sort by')" :value="query.sortBy" @ionChange="updateQuery('sortBy', $event.detail.value)" interface="popover">
+            <ion-select-option value="createdDate desc">{{ translate("Created date") }}</ion-select-option>
+            <ion-select-option value="dueDate desc">{{ translate("Due date") }}</ion-select-option>
+            <ion-select-option value="countImportName asc">{{ translate("Alphabetic") }}</ion-select-option>
+          </ion-select> 
+        </ion-item>
+      </div>
       <p v-if="!cycleCounts.length" class="empty-state">
         {{ translate("No cycle counts found") }}
       </p>
@@ -59,8 +69,8 @@
 <script setup lang="ts">
 import { computed, ref } from "vue";
 import { translate } from '@/i18n'
-import { filterOutline, storefrontOutline } from "ionicons/icons";
-import { IonBadge, IonButtons, IonChip, IonContent, IonHeader, IonIcon, IonItem, IonInfiniteScroll, IonInfiniteScrollContent, IonLabel, IonList, IonMenuButton, IonPage, IonSearchbar, IonTitle, IonToolbar, onIonViewDidEnter, onIonViewWillLeave } from "@ionic/vue";
+import { filterOutline, storefrontOutline, swapVerticalOutline } from "ionicons/icons";
+import { IonBadge, IonButtons, IonChip, IonContent, IonHeader, IonIcon, IonItem, IonInfiniteScroll, IonInfiniteScrollContent, IonLabel, IonList, IonMenuButton, IonPage, IonSearchbar, IonSelect, IonSelectOption, IonTitle, IonToolbar, onIonViewDidEnter, onIonViewWillLeave } from "@ionic/vue";
 import store from "@/store"
 import { getCycleCountStats, getDateWithOrdinalSuffix, getDerivedStatusForCount, getFacilityName } from "@/utils"
 import Filters from "@/components/Filters.vue"
@@ -122,6 +132,10 @@ async function fetchAssignedCycleCount(vSize?: any, vIndex?: any) {
   }
   await store.dispatch("count/fetchCycleCounts", payload)
 }
+
+async function updateQuery(key: string, value: any) {
+  await store.dispatch("count/updateQuery", { key, value })
+}
 </script>
 
 <style scoped>
@@ -132,5 +146,12 @@ async function fetchAssignedCycleCount(vSize?: any, vIndex?: any) {
 
 .list-item > ion-item {
   width: 100%;
+}
+
+.header {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  align-items: center;
+  gap: var(--spacer-xs);
 }
 </style>

--- a/src/views/Closed.vue
+++ b/src/views/Closed.vue
@@ -96,9 +96,6 @@ import {
   IonLabel,
   IonMenuButton,
   IonPage,
-  IonSearchbar,
-  IonSelect,
-  IonSelectOption,
   IonTitle,
   IonToolbar,
   modalController,
@@ -118,7 +115,6 @@ import router from "@/router"
 const cycleCounts = computed(() => store.getters["count/getCounts"])
 const cycleCountStats = computed(() => (id: string) => store.getters["count/getCycleCountStats"](id))
 const isScrollable = computed(() => store.getters["count/isCycleCountListScrollable"])
-const query = computed(() => store.getters["count/getQuery"])
 const closedCycleCountsTotal = computed(() => store.getters["count/getClosedCycleCountsTotal"])
 
 const isScrollingEnabled = ref(false);
@@ -215,9 +211,6 @@ ion-content {
 }
 
 .header {
-  display: grid;
   grid-template-columns: repeat(3, 1fr);
-  align-items: center;
-  gap: var(--spacer-xs);
 }
 </style>

--- a/src/views/Closed.vue
+++ b/src/views/Closed.vue
@@ -15,13 +15,13 @@
 
     <ion-content ref="contentRef" :scroll-events="true" @ionScroll="enableScrolling()" id="filter">
       <div class="header searchbar">
-        <SearchBarAndSortBy @emitUpdateQueryString="updateQueryString" />
+        <SearchBarAndSortBy @queryStringUpdated="queryStringUpdated" />
         <ion-item lines="full">
           <ion-icon slot="start" :icon="listOutline"/>
           <ion-label>{{ translate("Counts closed") }}</ion-label>
           <ion-label slot="end">{{ (closedCycleCountsTotal || closedCycleCountsTotal === 0) ? closedCycleCountsTotal : "-" }}</ion-label>
         </ion-item>
-        <!-- Currently the average variance does not work, so commenting it out for now -->
+        <!-- TODO: Need to add support to display average variance, currently the we do not have data for the same -->
         <!-- <ion-item lines="full">
           <ion-icon slot="start" :icon="thermometerOutline"/>
           <ion-label>{{ translate("Average variance") }}</ion-label>
@@ -145,7 +145,7 @@ function enableScrolling() {
   }
 }
 
-async function updateQueryString() {
+async function queryStringUpdated() {
   await Promise.allSettled([fetchClosedCycleCounts(), store.dispatch("count/fetchClosedCycleCountsTotal")])
 }
 

--- a/src/views/Closed.vue
+++ b/src/views/Closed.vue
@@ -15,15 +15,7 @@
 
     <ion-content ref="contentRef" :scroll-events="true" @ionScroll="enableScrolling()" id="filter">
       <div class="header searchbar">
-        <ion-searchbar v-model="query.queryString" @keyup.enter="updateQueryString('queryString', $event.target.value)" />
-        <ion-item lines="none">
-          <ion-icon slot="start" :icon="swapVerticalOutline" />
-          <ion-select :label="translate('Sort by')" :value="query.sortBy" @ionChange="updateQuery('sortBy', $event.detail.value)" interface="popover">
-            <ion-select-option value="createdDate desc">{{ translate("Created date") }}</ion-select-option>
-            <ion-select-option value="dueDate desc">{{ translate("Due date") }}</ion-select-option>
-            <ion-select-option value="countImportName asc">{{ translate("Alphabetic") }}</ion-select-option>
-          </ion-select> 
-        </ion-item>
+        <SearchBarAndSortBy @emitUpdateQueryString="updateQueryString" />
         <ion-item lines="full">
           <ion-icon slot="start" :icon="listOutline"/>
           <ion-label>{{ translate("Counts closed") }}</ion-label>
@@ -120,6 +112,7 @@ import Filters from "@/components/Filters.vue"
 import store from "@/store";
 import { getCycleCountStats, getDateWithOrdinalSuffix, getFacilityName } from "@/utils";
 import DownloadClosedCountModal from "@/components/DownloadClosedCountModal.vue";
+import SearchBarAndSortBy from "@/components/SearchBarAndSortBy.vue";
 import router from "@/router"
 
 const cycleCounts = computed(() => store.getters["count/getCounts"])
@@ -152,8 +145,7 @@ function enableScrolling() {
   }
 }
 
-async function updateQueryString(key: string, value: any) {
-  await store.dispatch("count/updateQueryString", { key, value })
+async function updateQueryString() {
   await Promise.allSettled([fetchClosedCycleCounts(), store.dispatch("count/fetchClosedCycleCountsTotal")])
 }
 
@@ -230,6 +222,6 @@ ion-content {
   display: grid;
   grid-template-columns: repeat(3, 1fr);
   align-items: center;
-  gap: 10px;
+  gap: var(--spacer-xs);
 }
 </style>

--- a/src/views/Closed.vue
+++ b/src/views/Closed.vue
@@ -16,16 +16,25 @@
     <ion-content ref="contentRef" :scroll-events="true" @ionScroll="enableScrolling()" id="filter">
       <div class="header searchbar">
         <ion-searchbar v-model="query.queryString" @keyup.enter="updateQueryString('queryString', $event.target.value)" />
+        <ion-item lines="none">
+          <ion-icon slot="start" :icon="swapVerticalOutline" />
+          <ion-select :label="translate('Sort by')" :value="query.sortBy" @ionChange="updateQuery('sortBy', $event.detail.value)" interface="popover">
+            <ion-select-option value="createdDate desc">{{ translate("Created date") }}</ion-select-option>
+            <ion-select-option value="dueDate desc">{{ translate("Due date") }}</ion-select-option>
+            <ion-select-option value="countImportName asc">{{ translate("Alphabetic") }}</ion-select-option>
+          </ion-select> 
+        </ion-item>
         <ion-item lines="full">
           <ion-icon slot="start" :icon="listOutline"/>
           <ion-label>{{ translate("Counts closed") }}</ion-label>
           <ion-label slot="end">{{ (closedCycleCountsTotal || closedCycleCountsTotal === 0) ? closedCycleCountsTotal : "-" }}</ion-label>
         </ion-item>
-        <ion-item lines="full">
+        <!-- Currently the average variance does not work, so commenting it out for now -->
+        <!-- <ion-item lines="full">
           <ion-icon slot="start" :icon="thermometerOutline"/>
           <ion-label>{{ translate("Average variance") }}</ion-label>
           <ion-label slot="end">{{ getAverageVariance() }}</ion-label>
-        </ion-item>
+        </ion-item> -->
       </div>
       <p v-if="!cycleCounts.length" class="empty-state">
         {{ translate("No cycle counts found") }}
@@ -96,13 +105,15 @@ import {
   IonMenuButton,
   IonPage,
   IonSearchbar,
+  IonSelect,
+  IonSelectOption,
   IonTitle,
   IonToolbar,
   modalController,
   onIonViewWillEnter,
   onIonViewWillLeave
 } from "@ionic/vue";
-import { cloudDownloadOutline, filterOutline, listOutline, storefrontOutline, thermometerOutline } from "ionicons/icons";
+import { cloudDownloadOutline, filterOutline, listOutline, storefrontOutline, swapVerticalOutline } from "ionicons/icons";
 import { computed, ref } from "vue"
 import { translate } from "@/i18n";
 import Filters from "@/components/Filters.vue"
@@ -196,6 +207,9 @@ async function openDownloadClosedCountModal() {
   await downloadClosedCountModal.present();
 }
 
+async function updateQuery(key: string, value: any) {
+  await store.dispatch("count/updateQuery", { key, value })
+}
 </script>
 
 <style scoped>
@@ -215,6 +229,7 @@ ion-content {
 .header {
   display: grid;
   grid-template-columns: repeat(3, 1fr);
+  align-items: center;
   gap: 10px;
 }
 </style>

--- a/src/views/Closed.vue
+++ b/src/views/Closed.vue
@@ -15,7 +15,7 @@
 
     <ion-content ref="contentRef" :scroll-events="true" @ionScroll="enableScrolling()" id="filter">
       <div class="header searchbar">
-        <SearchBarAndSortBy @queryStringUpdated="queryStringUpdated" />
+        <SearchBarAndSortBy />
         <ion-item lines="full">
           <ion-icon slot="start" :icon="listOutline"/>
           <ion-label>{{ translate("Counts closed") }}</ion-label>
@@ -139,10 +139,6 @@ function enableScrolling() {
   } else {
     isScrollingEnabled.value = true;
   }
-}
-
-async function queryStringUpdated() {
-  await Promise.allSettled([fetchClosedCycleCounts(), store.dispatch("count/fetchClosedCycleCountsTotal")])
 }
 
 async function loadMoreCycleCounts(event: any) {

--- a/src/views/Closed.vue
+++ b/src/views/Closed.vue
@@ -198,10 +198,6 @@ async function openDownloadClosedCountModal() {
 
   await downloadClosedCountModal.present();
 }
-
-async function updateQuery(key: string, value: any) {
-  await store.dispatch("count/updateQuery", { key, value })
-}
 </script>
 
 <style scoped>

--- a/src/views/Closed.vue
+++ b/src/views/Closed.vue
@@ -105,7 +105,7 @@ import {
   onIonViewWillEnter,
   onIonViewWillLeave
 } from "@ionic/vue";
-import { cloudDownloadOutline, filterOutline, listOutline, storefrontOutline, swapVerticalOutline } from "ionicons/icons";
+import { cloudDownloadOutline, filterOutline, listOutline, storefrontOutline } from "ionicons/icons";
 import { computed, ref } from "vue"
 import { translate } from "@/i18n";
 import Filters from "@/components/Filters.vue"

--- a/src/views/Closed.vue
+++ b/src/views/Closed.vue
@@ -14,7 +14,7 @@
     </ion-header>
 
     <ion-content ref="contentRef" :scroll-events="true" @ionScroll="enableScrolling()" id="filter">
-      <div class="header searchbar">
+      <div class="closed-header">
         <SearchBarAndSortBy />
         <ion-item lines="full">
           <ion-icon slot="start" :icon="listOutline"/>
@@ -206,7 +206,23 @@ ion-content {
   width: 100%;
 }
 
+.closed-header {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(0, 1fr));
+}
+
+.closed-header > ion-item {
+  padding-top: var(--spacer-base);
+  padding-inline: var(--spacer-sm);
+}
+
 .header {
-  grid-template-columns: repeat(3, 1fr);
+  grid-column: span 2;
+}
+
+@media (max-width: 991px) {
+  .closed-header {
+    grid-template-columns: 1fr;
+  }
 }
 </style>

--- a/src/views/Draft.vue
+++ b/src/views/Draft.vue
@@ -81,6 +81,8 @@ import {
   IonNote,
   IonPage,
   IonSearchbar,
+  IonSelect,
+  IonSelectOption,
   IonTitle,
   IonToolbar,
   alertController,
@@ -221,6 +223,7 @@ ion-note {
 .header {
   display: grid;
   grid-template-columns: repeat(2, 1fr);
-  gap: 10px;
+  align-items: center;
+  gap: var(--spacer-xs);
 }
 </style>

--- a/src/views/Draft.vue
+++ b/src/views/Draft.vue
@@ -15,7 +15,7 @@
 
     <ion-content ref="contentRef" :scroll-events="true" @ionScroll="enableScrolling()" id="filter">
       <div class="header searchbar">
-        <SearchBarAndSortBy @emitUpdateQueryString="updateQueryString" />
+        <SearchBarAndSortBy @queryStringUpdated="queryStringUpdated" />
       </div>
       <p v-if="!cycleCounts.length" class="empty-state">
         {{ translate("No cycle counts found") }}
@@ -121,7 +121,7 @@ function enableScrolling() {
   }
 }
 
-async function updateQueryString() {
+async function queryStringUpdated() {
   fetchDraftCycleCounts();
 }
 

--- a/src/views/Draft.vue
+++ b/src/views/Draft.vue
@@ -15,15 +15,7 @@
 
     <ion-content ref="contentRef" :scroll-events="true" @ionScroll="enableScrolling()" id="filter">
       <div class="header searchbar">
-        <ion-searchbar v-model="query.queryString" @keyup.enter="updateQueryString('queryString', $event.target.value)" />
-        <ion-item lines="none">
-          <ion-icon slot="start" :icon="swapVerticalOutline" />
-          <ion-select :label="translate('Sort by')" :value="query.sortBy" @ionChange="updateQuery('sortBy', $event.detail.value)" interface="popover">
-            <ion-select-option value="createdDate desc">{{ translate("Created date") }}</ion-select-option>
-            <ion-select-option value="dueDate desc">{{ translate("Due date") }}</ion-select-option>
-            <ion-select-option value="countImportName asc">{{ translate("Alphabetic") }}</ion-select-option>
-          </ion-select> 
-        </ion-item>
+        <SearchBarAndSortBy @emitUpdateQueryString="updateQueryString" />
       </div>
       <p v-if="!cycleCounts.length" class="empty-state">
         {{ translate("No cycle counts found") }}
@@ -97,6 +89,7 @@ import store from "@/store";
 import { showToast } from "@/utils";
 import router from "@/router";
 import { DateTime } from "luxon";
+import SearchBarAndSortBy from "@/components/SearchBarAndSortBy.vue";
 
 const cycleCounts = computed(() => store.getters["count/getCounts"])
 const cycleCountStats = computed(() => (id: string) => store.getters["count/getCycleCountStats"](id))
@@ -128,8 +121,7 @@ function enableScrolling() {
   }
 }
 
-async function updateQueryString(key: string, value: any) {
-  await store.dispatch("count/updateQueryString", { key, value })
+async function updateQueryString() {
   fetchDraftCycleCounts();
 }
 

--- a/src/views/Draft.vue
+++ b/src/views/Draft.vue
@@ -81,7 +81,7 @@ import {
   onIonViewDidEnter,
   onIonViewWillLeave
 } from "@ionic/vue";
-import { addOutline, documentOutline, documentsOutline, filterOutline, shieldCheckmarkOutline, swapVerticalOutline } from "ionicons/icons";
+import { addOutline, documentOutline, documentsOutline, filterOutline, shieldCheckmarkOutline } from "ionicons/icons";
 import { computed, ref } from "vue"
 import { translate } from "@/i18n";
 import Filters from "@/components/Filters.vue"

--- a/src/views/Draft.vue
+++ b/src/views/Draft.vue
@@ -14,9 +14,7 @@
     </ion-header>
 
     <ion-content ref="contentRef" :scroll-events="true" @ionScroll="enableScrolling()" id="filter">
-      <div class="header searchbar">
-        <SearchBarAndSortBy />
-      </div>
+      <SearchBarAndSortBy />
       <p v-if="!cycleCounts.length" class="empty-state">
         {{ translate("No cycle counts found") }}
       </p>

--- a/src/views/Draft.vue
+++ b/src/views/Draft.vue
@@ -15,7 +15,7 @@
 
     <ion-content ref="contentRef" :scroll-events="true" @ionScroll="enableScrolling()" id="filter">
       <div class="header searchbar">
-        <SearchBarAndSortBy @queryStringUpdated="queryStringUpdated" />
+        <SearchBarAndSortBy />
       </div>
       <p v-if="!cycleCounts.length" class="empty-state">
         {{ translate("No cycle counts found") }}
@@ -115,10 +115,6 @@ function enableScrolling() {
   } else {
     isScrollingEnabled.value = true;
   }
-}
-
-async function queryStringUpdated() {
-  fetchDraftCycleCounts();
 }
 
 async function loadMoreCycleCounts(event: any) {

--- a/src/views/Draft.vue
+++ b/src/views/Draft.vue
@@ -198,10 +198,6 @@ async function createCycleCount() {
 
   return createCountAlert.present();
 }
-
-async function updateQuery(key: string, value: any) {
-  await store.dispatch("count/updateQuery", { key, value })
-}
 </script>
 
 <style scoped>

--- a/src/views/Draft.vue
+++ b/src/views/Draft.vue
@@ -14,7 +14,17 @@
     </ion-header>
 
     <ion-content ref="contentRef" :scroll-events="true" @ionScroll="enableScrolling()" id="filter">
-      <ion-searchbar class="searchbar" v-model="query.queryString" @keyup.enter="updateQueryString('queryString', $event.target.value)" />
+      <div class="header searchbar">
+        <ion-searchbar v-model="query.queryString" @keyup.enter="updateQueryString('queryString', $event.target.value)" />
+        <ion-item lines="none">
+          <ion-icon slot="start" :icon="swapVerticalOutline" />
+          <ion-select :label="translate('Sort by')" :value="query.sortBy" @ionChange="updateQuery('sortBy', $event.detail.value)" interface="popover">
+            <ion-select-option value="createdDate desc">{{ translate("Created date") }}</ion-select-option>
+            <ion-select-option value="dueDate desc">{{ translate("Due date") }}</ion-select-option>
+            <ion-select-option value="countImportName asc">{{ translate("Alphabetic") }}</ion-select-option>
+          </ion-select> 
+        </ion-item>
+      </div>
       <p v-if="!cycleCounts.length" class="empty-state">
         {{ translate("No cycle counts found") }}
       </p>
@@ -77,7 +87,7 @@ import {
   onIonViewDidEnter,
   onIonViewWillLeave
 } from "@ionic/vue";
-import { addOutline, documentOutline, documentsOutline, filterOutline, shieldCheckmarkOutline } from "ionicons/icons";
+import { addOutline, documentOutline, documentsOutline, filterOutline, shieldCheckmarkOutline, swapVerticalOutline } from "ionicons/icons";
 import { computed, ref } from "vue"
 import { translate } from "@/i18n";
 import Filters from "@/components/Filters.vue"
@@ -194,6 +204,10 @@ async function createCycleCount() {
 
   return createCountAlert.present();
 }
+
+async function updateQuery(key: string, value: any) {
+  await store.dispatch("count/updateQuery", { key, value })
+}
 </script>
 
 <style scoped>
@@ -203,5 +217,10 @@ async function createCycleCount() {
 ion-note {
   align-self: center;
   padding: 0;
+}
+.header {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 10px;
 }
 </style>

--- a/src/views/Draft.vue
+++ b/src/views/Draft.vue
@@ -72,9 +72,6 @@ import {
   IonMenuButton,
   IonNote,
   IonPage,
-  IonSearchbar,
-  IonSelect,
-  IonSelectOption,
   IonTitle,
   IonToolbar,
   alertController,
@@ -94,7 +91,6 @@ import SearchBarAndSortBy from "@/components/SearchBarAndSortBy.vue";
 const cycleCounts = computed(() => store.getters["count/getCounts"])
 const cycleCountStats = computed(() => (id: string) => store.getters["count/getCycleCountStats"](id))
 const isScrollable = computed(() => store.getters["count/isCycleCountListScrollable"])
-const query = computed(() => store.getters["count/getQuery"])
 const userProfile = computed(() => store.getters["user/getUserProfile"])
 
 const isScrollingEnabled = ref(false);
@@ -207,11 +203,5 @@ async function createCycleCount() {
 ion-note {
   align-self: center;
   padding: 0;
-}
-.header {
-  display: grid;
-  grid-template-columns: repeat(2, 1fr);
-  align-items: center;
-  gap: var(--spacer-xs);
 }
 </style>

--- a/src/views/PendingReview.vue
+++ b/src/views/PendingReview.vue
@@ -60,7 +60,7 @@
 
 <script setup lang="ts">
 import { translate } from '@/i18n'
-import { filterOutline, storefrontOutline, swapVerticalOutline } from "ionicons/icons";
+import { filterOutline, storefrontOutline } from "ionicons/icons";
 import { IonButtons, IonBadge, IonChip, IonContent, IonHeader, IonIcon, IonItem, IonInfiniteScroll, IonInfiniteScrollContent, IonLabel, IonList, IonMenuButton, IonPage, IonSearchbar,IonSelect, IonSelectOption, IonTitle, IonToolbar, onIonViewWillLeave, onIonViewDidEnter } from "@ionic/vue";
 import { computed, ref } from "vue"
 import store from "@/store"

--- a/src/views/PendingReview.vue
+++ b/src/views/PendingReview.vue
@@ -124,10 +124,6 @@ async function fetchPendingCycleCounts(vSize?: any, vIndex?: any) {
   }
   await store.dispatch("count/fetchCycleCounts", payload)
 }
-
-async function updateQuery(key: string, value: any) {
-  await store.dispatch("count/updateQuery", { key, value })
-}
 </script>
 
 <style scoped>

--- a/src/views/PendingReview.vue
+++ b/src/views/PendingReview.vue
@@ -14,7 +14,7 @@
 
     <ion-content ref="contentRef" :scroll-events="true" @ionScroll="enableScrolling()" id="filter">
       <div class="header searchbar">
-        <SearchBarAndSortBy @emitUpdateQueryString="updateQueryString" />
+        <SearchBarAndSortBy @queryStringUpdated="queryStringUpdated" />
       </div>
       <p v-if="!cycleCounts.length" class="empty-state">
         {{ translate("No cycle counts found") }}
@@ -97,7 +97,7 @@ function enableScrolling() {
   }
 }
 
-async function updateQueryString() {
+async function queryStringUpdated() {
   fetchPendingCycleCounts();
 }
 

--- a/src/views/PendingReview.vue
+++ b/src/views/PendingReview.vue
@@ -61,7 +61,7 @@
 <script setup lang="ts">
 import { translate } from '@/i18n'
 import { filterOutline, storefrontOutline } from "ionicons/icons";
-import { IonButtons, IonBadge, IonChip, IonContent, IonHeader, IonIcon, IonItem, IonInfiniteScroll, IonInfiniteScrollContent, IonLabel, IonList, IonMenuButton, IonPage, IonSearchbar,IonSelect, IonSelectOption, IonTitle, IonToolbar, onIonViewWillLeave, onIonViewDidEnter } from "@ionic/vue";
+import { IonButtons, IonBadge, IonChip, IonContent, IonHeader, IonIcon, IonItem, IonInfiniteScroll, IonInfiniteScrollContent, IonLabel, IonList, IonMenuButton, IonPage, IonTitle, IonToolbar, onIonViewWillLeave, onIonViewDidEnter } from "@ionic/vue";
 import { computed, ref } from "vue"
 import store from "@/store"
 import router from "@/router"
@@ -71,7 +71,6 @@ import SearchBarAndSortBy from "@/components/SearchBarAndSortBy.vue";
 
 const cycleCounts = computed(() => store.getters["count/getCounts"])
 const isScrollable = computed(() => store.getters["count/isCycleCountListScrollable"])
-const query = computed(() => store.getters["count/getQuery"])
 
 const isScrollingEnabled = ref(false);
 const contentRef = ref({}) as any
@@ -134,12 +133,5 @@ async function fetchPendingCycleCounts(vSize?: any, vIndex?: any) {
 
 .list-item > ion-item {
   width: 100%;
-}
-
-.header {
-  display: grid;
-  grid-template-columns: repeat(2, 1fr);
-  align-items: center;
-  gap: var(--spacer-xs);
 }
 </style>

--- a/src/views/PendingReview.vue
+++ b/src/views/PendingReview.vue
@@ -13,9 +13,7 @@
     </ion-header>
 
     <ion-content ref="contentRef" :scroll-events="true" @ionScroll="enableScrolling()" id="filter">
-      <div class="header searchbar">
-        <SearchBarAndSortBy />
-      </div>
+      <SearchBarAndSortBy />
       <p v-if="!cycleCounts.length" class="empty-state">
         {{ translate("No cycle counts found") }}
       </p>

--- a/src/views/PendingReview.vue
+++ b/src/views/PendingReview.vue
@@ -14,7 +14,7 @@
 
     <ion-content ref="contentRef" :scroll-events="true" @ionScroll="enableScrolling()" id="filter">
       <div class="header searchbar">
-        <SearchBarAndSortBy @queryStringUpdated="queryStringUpdated" />
+        <SearchBarAndSortBy />
       </div>
       <p v-if="!cycleCounts.length" class="empty-state">
         {{ translate("No cycle counts found") }}
@@ -94,10 +94,6 @@ function enableScrolling() {
   } else {
     isScrollingEnabled.value = true;
   }
-}
-
-async function queryStringUpdated() {
-  fetchPendingCycleCounts();
 }
 
 async function loadMoreCycleCounts(event: any) {

--- a/src/views/PendingReview.vue
+++ b/src/views/PendingReview.vue
@@ -14,15 +14,7 @@
 
     <ion-content ref="contentRef" :scroll-events="true" @ionScroll="enableScrolling()" id="filter">
       <div class="header searchbar">
-        <ion-searchbar v-model="query.queryString" @keyup.enter="updateQueryString('queryString', $event.target.value)" />
-        <ion-item lines="none">
-          <ion-icon slot="start" :icon="swapVerticalOutline" />
-          <ion-select :label="translate('Sort by')" :value="query.sortBy" @ionChange="updateQuery('sortBy', $event.detail.value)" interface="popover">
-            <ion-select-option value="createdDate desc">{{ translate("Created date") }}</ion-select-option>
-            <ion-select-option value="dueDate desc">{{ translate("Due date") }}</ion-select-option>
-            <ion-select-option value="countImportName asc">{{ translate("Alphabetic") }}</ion-select-option>
-          </ion-select> 
-        </ion-item>
+        <SearchBarAndSortBy @emitUpdateQueryString="updateQueryString" />
       </div>
       <p v-if="!cycleCounts.length" class="empty-state">
         {{ translate("No cycle counts found") }}
@@ -75,6 +67,7 @@ import store from "@/store"
 import router from "@/router"
 import Filters from "@/components/Filters.vue"
 import { getCycleCountStats, getDateWithOrdinalSuffix, getDerivedStatusForCount, getFacilityName } from "@/utils"
+import SearchBarAndSortBy from "@/components/SearchBarAndSortBy.vue";
 
 const cycleCounts = computed(() => store.getters["count/getCounts"])
 const isScrollable = computed(() => store.getters["count/isCycleCountListScrollable"])
@@ -104,8 +97,7 @@ function enableScrolling() {
   }
 }
 
-async function updateQueryString(key: string, value: any) {
-  await store.dispatch("count/updateQueryString", { key, value })
+async function updateQueryString() {
   fetchPendingCycleCounts();
 }
 

--- a/src/views/PendingReview.vue
+++ b/src/views/PendingReview.vue
@@ -13,7 +13,17 @@
     </ion-header>
 
     <ion-content ref="contentRef" :scroll-events="true" @ionScroll="enableScrolling()" id="filter">
-      <ion-searchbar class="searchbar" v-model="query.queryString" @keyup.enter="updateQueryString('queryString', $event.target.value)" />
+      <div class="header searchbar">
+        <ion-searchbar v-model="query.queryString" @keyup.enter="updateQueryString('queryString', $event.target.value)" />
+        <ion-item lines="none">
+          <ion-icon slot="start" :icon="swapVerticalOutline" />
+          <ion-select :label="translate('Sort by')" :value="query.sortBy" @ionChange="updateQuery('sortBy', $event.detail.value)" interface="popover">
+            <ion-select-option value="createdDate desc">{{ translate("Created date") }}</ion-select-option>
+            <ion-select-option value="dueDate desc">{{ translate("Due date") }}</ion-select-option>
+            <ion-select-option value="countImportName asc">{{ translate("Alphabetic") }}</ion-select-option>
+          </ion-select> 
+        </ion-item>
+      </div>
       <p v-if="!cycleCounts.length" class="empty-state">
         {{ translate("No cycle counts found") }}
       </p>
@@ -58,8 +68,8 @@
 
 <script setup lang="ts">
 import { translate } from '@/i18n'
-import { filterOutline, storefrontOutline } from "ionicons/icons";
-import { IonButtons, IonBadge, IonChip, IonContent, IonHeader, IonIcon, IonItem, IonInfiniteScroll, IonInfiniteScrollContent, IonLabel, IonList, IonMenuButton, IonPage, IonSearchbar, IonTitle, IonToolbar, onIonViewWillLeave, onIonViewDidEnter } from "@ionic/vue";
+import { filterOutline, storefrontOutline, swapVerticalOutline } from "ionicons/icons";
+import { IonButtons, IonBadge, IonChip, IonContent, IonHeader, IonIcon, IonItem, IonInfiniteScroll, IonInfiniteScrollContent, IonLabel, IonList, IonMenuButton, IonPage, IonSearchbar,IonSelect, IonSelectOption, IonTitle, IonToolbar, onIonViewWillLeave, onIonViewDidEnter } from "@ionic/vue";
 import { computed, ref } from "vue"
 import store from "@/store"
 import router from "@/router"
@@ -122,6 +132,10 @@ async function fetchPendingCycleCounts(vSize?: any, vIndex?: any) {
   }
   await store.dispatch("count/fetchCycleCounts", payload)
 }
+
+async function updateQuery(key: string, value: any) {
+  await store.dispatch("count/updateQuery", { key, value })
+}
 </script>
 
 <style scoped>
@@ -132,5 +146,12 @@ async function fetchPendingCycleCounts(vSize?: any, vIndex?: any) {
 
 .list-item > ion-item {
   width: 100%;
+}
+
+.header {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  align-items: center;
+  gap: var(--spacer-xs);
 }
 </style>


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#631

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
- Previously, the `Sort By` filtering was present in the `Filters` section on various pages. This filtering included sorting by `due date` and `alphabetically`.  
- Now I have added the `Sort By` option adjacent to the search bar. It now includes three options: `Created Date` (default), `Due Date`, and `Alphabetical`.  
- The `Created Date` sorting arranges the cycle count in `descending order`, meaning the most recently created items appear at the top of the list. The same pattern is applied to `Due Date` sorting.  

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->
![image](https://github.com/user-attachments/assets/83ff54a3-b60c-41ac-9b6e-f3eda6ef8ad6)
![image](https://github.com/user-attachments/assets/dc19a769-d0ad-4484-892d-723823070f81)


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I have read and followed [contribution rules](https://github.com/hotwax/inventory-count#contribution-guideline)
