### PR TITLE
Improved: Added support to fetch the total closed count after applying date filters (#682)

### DIFF
--- a/src/store/modules/count/actions.ts
+++ b/src/store/modules/count/actions.ts
@@ -189,15 +189,17 @@ const actions: ActionTree<CountState, RootState> = {
     // After updating query we need to fetch the counts and thus need to pass the statusId for the counts to be fetched
     // hence added check to decide the statusId on the basis of currently selected router
     let statusId = "INV_COUNT_CREATED"
+    let statusId_op = "equals"
     if(router.currentRoute.value.name === "PendingReview") {
       statusId = "INV_COUNT_REVIEW"
     } else if(router.currentRoute.value.name === "Assigned") {
       statusId = "INV_COUNT_ASSIGNED"
     } else if(router.currentRoute.value.name === "Closed") {
-      statusId = "INV_COUNT_COMPLETED, INV_COUNT_REJECTED"
+      statusId = "INV_COUNT_COMPLETED, INV_COUNT_REJECTED",
+      statusId_op = "in"
     }
-    // Conditionally append 'statusId_op' operator to support multiple status IDs filtering
-    dispatch("fetchCycleCounts", { pageSize: process.env.VUE_APP_VIEW_SIZE, pageIndex: 0, statusId, ...(statusId.includes(',') && { statusId_op: "in" })})
+    // append 'statusId_op' operator to support multiple status IDs filtering & equals for single status ID
+    dispatch("fetchCycleCounts", { pageSize: process.env.VUE_APP_VIEW_SIZE, pageIndex: 0, statusId, statusId_op })
     if(payload.key && statusId.includes("INV_COUNT_COMPLETED")) dispatch("fetchClosedCycleCountsTotal")
   },
 


### PR DESCRIPTION

### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#682 

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->

- Added support for applying date filters while fetching the closed count.  
- Also updated the `statusId` field and included `INV_COUNT_REJECTED` while fetching the closed count, as this status is only added to the query during the initial fetch after landing on the page.  
- Additionally, added the same check for including `INV_COUNT_REJECTED` in both the `statusId` and the `statusId` operator condition while fetching the closed cycle count after applying filters.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I have read and followed [contribution rules](https://github.com/hotwax/inventory-count#contribution-guideline)
