### PR TITLE
Implemented: Count on first scan feature(#702)

### DIFF
--- a/src/components/ForceScanCard.vue
+++ b/src/components/ForceScanCard.vue
@@ -11,6 +11,11 @@
         {{ translate("Require barcode scanning") }}
       </ion-toggle>
     </ion-item>
+    <ion-item v-if="!router.currentRoute.value.fullPath.includes('/tabs/')" lines="none" :disabled="!hasPermission('APP_DRAFT_VIEW')">
+      <ion-toggle :checked="productStoreSettings['isFirstScanCountEnabled']" @click.prevent="updateProductStoreSetting($event, 'isFirstScanCountEnabled')">
+        {{ translate("Count on first scan") }}
+      </ion-toggle>
+    </ion-item>
     <ion-item lines="none" :disabled="!hasPermission('APP_DRAFT_VIEW')">
       <ion-select :label="translate('Barcode Identifier')" interface="popover" :placeholder="translate('Select')" :value="productStoreSettings['barcodeIdentificationPref']" @ionChange="setBarcodeIdentificationPref($event.detail.value)">
         <ion-select-option v-for="identification in productIdentifications" :key="identification.goodIdentificationTypeId" :value="identification.goodIdentificationTypeId" >{{ identification.description ? identification.description : identification.goodIdentificationTypeId }}</ion-select-option>
@@ -32,6 +37,7 @@ import {
 } from "@ionic/vue";
 import { translate } from '@/i18n'
 import store from "@/store";
+import router from "@/router";
 import { computed } from "vue";
 import { hasPermission } from "@/authorization"
 import { useProductIdentificationStore } from "@hotwax/dxp-components";

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -68,6 +68,7 @@
   "count items were recounted": "{count} count items were recounted",
   "Count name": "Count name",
   "count name": "count name",
+  "Count on first scan": "Count on first scan",
   "count pending": "count pending",
   "Counts": "Counts",
   "Counts closed": "Counts closed",

--- a/src/store/modules/user/UserState.ts
+++ b/src/store/modules/user/UserState.ts
@@ -15,6 +15,7 @@ export default interface UserState {
     value: object;
   },
   settings: {
+    isFirstScanCountEnabled: boolean;
     forceScan: boolean,
     showQoh: boolean,
     barcodeIdentificationPref: string;

--- a/src/store/modules/user/actions.ts
+++ b/src/store/modules/user/actions.ts
@@ -175,7 +175,7 @@ const actions: ActionTree<UserState, RootState> = {
   },
 
   async updateCurrentProductStore({ commit, dispatch }, selectedProductStore) {
-    commit(types.USER_PRODUCT_STORE_SETTING_UPDATED, { showQoh: false, forceScan: false, barcodeIdentificationPref: "internalName" })
+    commit(types.USER_PRODUCT_STORE_SETTING_UPDATED, { showQoh: false, forceScan: false, isFirstScanCountEnabled: false, barcodeIdentificationPref: "internalName" })
 
     await useProductIdentificationStore().getIdentificationPref(selectedProductStore.productStoreId)
       .catch((error) => logger.error(error));
@@ -185,7 +185,7 @@ const actions: ActionTree<UserState, RootState> = {
   async getProductStoreSetting({ commit }, productStoreId?: string) {
     const payload = {
       "productStoreId": productStoreId ? productStoreId : getProductStoreId(),
-      "settingTypeEnumId": "INV_CNT_VIEW_QOH,INV_FORCE_SCAN,BARCODE_IDEN_PREF",
+      "settingTypeEnumId": "INV_CNT_VIEW_QOH,INV_FORCE_SCAN,INV_COUNT_FIRST_SCAN,BARCODE_IDEN_PREF",
       "settingTypeEnumId_op": "in",
       "pageSize": 10
     }
@@ -202,6 +202,10 @@ const actions: ActionTree<UserState, RootState> = {
             settings["forceScan"] = JSON.parse(setting.settingValue)
           }
 
+          if(setting.settingTypeEnumId === "INV_COUNT_FIRST_SCAN" && setting.settingValue) {
+            settings["isFirstScanCountEnabled"] = JSON.parse(setting.settingValue)
+          }
+
           if(setting.settingTypeEnumId === "BARCODE_IDEN_PREF" && setting.settingValue) {
             settings["barcodeIdentificationPref"] = setting.settingValue
           }
@@ -209,6 +213,7 @@ const actions: ActionTree<UserState, RootState> = {
         }, {
           showQoh: false,
           forceScan: false,
+          isFirstScanCountEnabled: false,
           barcodeIdentificationPref: "internalName"
         })
         commit(types.USER_PRODUCT_STORE_SETTING_UPDATED, settings)
@@ -256,6 +261,10 @@ const actions: ActionTree<UserState, RootState> = {
 
     if(payload.key === "forceScan") {
       enumId = "INV_FORCE_SCAN"
+    }
+
+    if(payload.key === "isFirstScanCountEnabled") {
+      enumId = "INV_COUNT_FIRST_SCAN"
     }
 
     if(payload.key === "barcodeIdentificationPref") {

--- a/src/store/modules/user/index.ts
+++ b/src/store/modules/user/index.ts
@@ -24,6 +24,7 @@ const userModule: Module<UserState, RootState> = {
         value: {}
       },
       settings: {
+        isFirstScanCountEnabled: false,
         forceScan: false,
         showQoh: false,
         barcodeIdentificationPref: ""


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#702 

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
- Added a toggle on the Force Scan Card for the Admin Store Permission page.
- Managed the product store setting and used them on the CountDetail and HardCountDetail pages.
- Added count increment when the toggle is enabled for both normal and hard count, and handled various cases with scrolling animations enabled.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I have read and followed [contribution rules](https://github.com/hotwax/inventory-count#contribution-guideline)
