### PR TITLE
Fixed: When scrolling animation is disabled, the counting will start on the first scan.

### DIFF
--- a/src/views/CountDetail.vue
+++ b/src/views/CountDetail.vue
@@ -472,6 +472,10 @@ async function scanProduct() {
     if(productStoreSettings.value["isFirstScanCountEnabled"] && selectedItem.quantity >= 0) {
       openRecountAlert()
     }
+    // increment inputCount when scrolling animation is disabled and first scan count is enabled
+    if(!isScrollingAnimationEnabled.value) {
+      if(productStoreSettings.value["isFirstScanCountEnabled"]) inputCount.value++;
+    }
   } else if(cycleCount.value.statusId === "INV_COUNT_ASSIGNED" && selectedItem.itemStatusId === "INV_COUNT_CREATED") {
     if((!selectedItem.quantity && selectedItem.quantity !== 0) || product.value.isRecounting) {
       hasUnsavedChanges.value = true;


### PR DESCRIPTION

### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->


### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I have read and followed [contribution rules](https://github.com/hotwax/inventory-count#contribution-guideline)
