### PR TITLE
Fixed: Added a change that prevents the inputCount from incrementing on tab change (#752)

### DIFF
--- a/src/views/CountDetail.vue
+++ b/src/views/CountDetail.vue
@@ -542,7 +542,7 @@ function initializeObserver() {
           }
         }
         // update the input count when the first scan count is enabled and the current product matches the scanned item
-        if(productStoreSettings.value["isFirstScanCountEnabled"] && currentProduct.productId === scannedItem.value.productId && currentProduct.importItemSeqId === scannedItem.value.importItemSeqId && !scannedItem.value.quantity && scannedItem.value.quantity !== 0) {
+        if(productStoreSettings.value["isFirstScanCountEnabled"] && currentProduct.productId === scannedItem.value.productId && currentProduct.importItemSeqId === scannedItem.value.importItemSeqId && !scannedItem.value.quantity && scannedItem.value.quantity !== 0 && !hasUnsavedChanges.value) {
           hasUnsavedChanges.value = true;
           inputCount.value++;
           scannedItem.value = {};


### PR DESCRIPTION

### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#752 

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
- When a user scans a product that initially doesn't have any quantity, and after a few scans the quantity increments, switching the segment (with scrolling animation and first scan count enabled) causes an unnecessary increment of the inputCount.
- This issue has now been fixed. The auto-increment of the count on segment change has been resolved, and the last counted value of the item will now persist on the screen after changing the segment, without incrementing further.


### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I have read and followed [contribution rules](https://github.com/hotwax/inventory-count#contribution-guideline)
