### PR TITLE
Implemented: added support for soft-deleting an item from the assigned details page (#778)

### DIFF
--- a/src/store/modules/count/actions.ts
+++ b/src/store/modules/count/actions.ts
@@ -292,13 +292,20 @@ const actions: ActionTree<CountState, RootState> = {
             // field, thus only updating required items in the dbItems
             if(dbData?.data?.length) {
               respItems.forEach((item: any) => {
-                dbItems[item.importItemSeqId] = item
+                if(item.statusId === "INV_COUNT_VOIDED") {
+                  // If the item is voided and already exists in dbItems, remove it
+                  if(dbItems[item.importItemSeqId]) delete dbItems[item.importItemSeqId];
+                } else {
+                  // Otherwise, update or insert the item
+                  dbItems[item.importItemSeqId] = item;
+                }
               })
 
               // As we are directly updating the dbItems, thus not using concat and directly updating the items
               items = Object.values(dbItems)
             } else {
-              items = items.concat(respItems)
+              // Filter out voided items before adding to items when indexedDB does not have any saved items.
+              items = items.concat(respItems.filter((item: any) => item.statusId !== "INV_COUNT_VOIDED"))
             }
 
             // dispatch progress update after each batch

--- a/src/utils/indexeddb.ts
+++ b/src/utils/indexeddb.ts
@@ -17,26 +17,15 @@ function syncItem(values: any, table: any, key: any, database: string) {
       const objStore = tran.objectStore(table);
       // @ts-ignore
       objStore.get(key).onsuccess = ({ target: { result } }) => {
-        if (!result) {
-          const data = new Map();
-          values.map((value: any) => {
-            data.set(value[recordKey], value)
-          })
-          objStore.add({
-            lastUpdatedStamp: Date.now(),
-            data
-          }, key).onsuccess = res;
-        } else {
-          const data = result.data
-          values.map((value: any) => {
-            data.set(value[recordKey], value)
-          })
-
-          objStore.put({
-            lastUpdatedStamp: Date.now(),
-            data
-          }, key).onsuccess = res;
-        }
+        // Always overwrites the object store entry with the latest values mapped by key and a timestamp
+        const data = new Map();
+        values.map((value: any) => {
+          data.set(value[recordKey], value)
+        })
+        objStore.put({
+          lastUpdatedStamp: Date.now(),
+          data
+        }, key).onsuccess = res;
       };
     };
   });

--- a/src/views/AssignedDetail.vue
+++ b/src/views/AssignedDetail.vue
@@ -293,17 +293,17 @@ async function updateCountName() {
   isCountNameUpdating.value = false
 }
 
-async function deleteItemFromCount(item: any) {
+async function deleteItemFromCount(countItem: any) {
   try {
     const resp = await CountService.updateCount({
       inventoryCountImportId: currentCycleCount.value.countId,
-      importItemSeqId: item.importItemSeqId,
+      importItemSeqId: countItem.importItemSeqId,
       statusId: "INV_COUNT_VOIDED",
-      productId: item.productId
+      productId: countItem.productId
     })
 
     if(!hasError(resp)) {
-      currentCycleCount.value.items = currentCycleCount.value.items.filter((itm: any) => itm.importItemSeqId !== item.importItemSeqId)
+      currentCycleCount.value.items = currentCycleCount.value.items.filter((item: any) => item.importItemSeqId !== countItem.importItemSeqId)
       showToast(translate("Item has been removed from the cycle count"))
     } else {
       throw "Failed to remove the item from the count"

--- a/src/views/AssignedDetail.vue
+++ b/src/views/AssignedDetail.vue
@@ -249,6 +249,7 @@ async function fetchCountItems() {
 
   try {
     do {
+      // itemStatusId: "INV_COUNT_VOIDED", itemStatusId_not: "Y", itemStatusId_op: "in"
       resp = await CountService.fetchCycleCountItems({ inventoryCountImportId : props?.inventoryCountImportId, pageSize: 100, pageIndex })
       if(!hasError(resp) && resp.data?.itemList?.length) {
         items = items.concat(resp.data.itemList)
@@ -293,15 +294,17 @@ async function updateCountName() {
   isCountNameUpdating.value = false
 }
 
-async function deleteItemFromCount(seqId: string) {
+async function deleteItemFromCount(item: any) {
   try {
-    const resp = await CountService.deleteCycleCountItem({
+    const resp = await CountService.updateCount({
       inventoryCountImportId: currentCycleCount.value.countId,
-      importItemSeqId: seqId
+      importItemSeqId: item.importItemSeqId,
+      statusId: "INV_COUNT_VOIDED",
+      productId: item.productId
     })
 
     if(!hasError(resp)) {
-      currentCycleCount.value.items = currentCycleCount.value.items.filter((item: any) => item.importItemSeqId !== seqId)
+      currentCycleCount.value.items = currentCycleCount.value.items.filter((itm: any) => itm.importItemSeqId !== item.importItemSeqId)
       showToast(translate("Item has been removed from the cycle count"))
     } else {
       throw "Failed to remove the item from the count"
@@ -329,7 +332,7 @@ async function openAssignedCountPopover(event: any, item: any){
     }
 
     if(result.data?.itemAction === "remove") {
-      await deleteItemFromCount(item.importItemSeqId)
+      await deleteItemFromCount(item)
     }
   })
 

--- a/src/views/AssignedDetail.vue
+++ b/src/views/AssignedDetail.vue
@@ -249,7 +249,6 @@ async function fetchCountItems() {
 
   try {
     do {
-      // itemStatusId: "INV_COUNT_VOIDED", itemStatusId_not: "Y", itemStatusId_op: "in"
       resp = await CountService.fetchCycleCountItems({ inventoryCountImportId : props?.inventoryCountImportId, pageSize: 100, pageIndex })
       if(!hasError(resp) && resp.data?.itemList?.length) {
         items = items.concat(resp.data.itemList)


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#778

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
- Added support to set statusId to `INV_COUNT_VOIDED` on item soft delete
- Excluded voided items from the count details page on the store view side
- Removed voided items from IndexedDB after receiving soft delete from the admin side

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I have read and followed [contribution rules](https://github.com/hotwax/inventory-count#contribution-guideline)
