### PR TITLE
Improved: Used frame-ancestors in CSP security header instead of X-Frame-Options (#104).

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -14,13 +14,10 @@
       } ],
       "headers": [ {
         "source": "**",
-        "headers": [ {
-          "key": "X-Frame-Options",
-          "value": "SAMEORIGIN"
-        },
+        "headers": [
         {
           "key": "Content-Security-Policy",
-          "value": "default-src 'self';font-src 'self' data: *;script-src 'self' 'unsafe-inline' 'unsafe-eval' fonts.googleapis.com;img-src 'self' 'unsafe-inline' *.shopify.com javascript: ;style-src 'self' 'unsafe-inline' *; connect-src 'self' *"
+          "value": "default-src 'self';font-src 'self' data: *;script-src 'self' 'unsafe-inline' 'unsafe-eval' fonts.googleapis.com;img-src 'self' 'unsafe-inline' *.shopify.com javascript: ;style-src 'self' 'unsafe-inline' *; connect-src 'self' *; frame-ancestors https://admin.shopify.com https://*.myshopify.com;"
         },
         {
           "key": "strict-transport-security",
@@ -45,13 +42,10 @@
       } ],
       "headers": [ {
         "source": "**",
-        "headers": [ {
-          "key": "X-Frame-Options",
-          "value": "SAMEORIGIN"
-        },
+        "headers": [
         {
           "key": "Content-Security-Policy",
-          "value": "default-src 'self';font-src 'self' data: *;script-src 'self' 'unsafe-inline' 'unsafe-eval' fonts.googleapis.com;img-src 'self' 'unsafe-inline' *.shopify.com javascript: ;style-src 'self' 'unsafe-inline' *; connect-src 'self' *"
+          "value": "default-src 'self';font-src 'self' data: *;script-src 'self' 'unsafe-inline' 'unsafe-eval' fonts.googleapis.com;img-src 'self' 'unsafe-inline' *.shopify.com javascript: ;style-src 'self' 'unsafe-inline' *; connect-src 'self' *; frame-ancestors https://admin.shopify.com https://*.myshopify.com;"
         },
         {
           "key": "strict-transport-security",
@@ -76,13 +70,10 @@
       } ],
       "headers": [ {
         "source": "**",
-        "headers": [ {
-          "key": "X-Frame-Options",
-          "value": "SAMEORIGIN"
-        },
+        "headers": [
         {
           "key": "Content-Security-Policy",
-          "value": "default-src 'self';font-src 'self' data: *;script-src 'self' 'unsafe-inline' 'unsafe-eval' fonts.googleapis.com;img-src 'self' 'unsafe-inline' *.shopify.com javascript: ;style-src 'self' 'unsafe-inline' *; connect-src 'self' *"
+          "value": "default-src 'self';font-src 'self' data: *;script-src 'self' 'unsafe-inline' 'unsafe-eval' fonts.googleapis.com;img-src 'self' 'unsafe-inline' *.shopify.com javascript: ;style-src 'self' 'unsafe-inline' *; connect-src 'self' *; frame-ancestors https://admin.shopify.com https://*.myshopify.com;"
         },
         {
           "key": "strict-transport-security",


### PR DESCRIPTION
### Related Issues
#104

#

### Short Description and Why It's Useful
Improved: Used frame-ancestors in CSP security header instead of X-Frame-Options (https://github.com/hotwax/fulfillment/pull/104).


### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [ ] I have read and followed [contribution rules](https://github.com/hotwax/inventory-count#contribution-guideline)
