### PR TITLE
Add button for admins to access store interface-754

### DIFF
--- a/src/views/Settings.vue
+++ b/src/views/Settings.vue
@@ -29,6 +29,9 @@
             {{ translate("Go to Launchpad") }}
             <ion-icon slot="end" :icon="openOutline" />
           </ion-button>
+         <ion-button v-if="(router.currentRoute.value.fullPath.includes('/tabs/') && cameFromAdmin) ||!router.currentRoute.value.fullPath.includes('/tabs/')" color="danger" @click="goToTabs()">
+            {{ router.currentRoute.value.fullPath.includes('/tabs/') ? translate("go to admin") : translate("go to store") }}
+         </ion-button>
         </ion-card>
       </div>
       <div class="section-header">
@@ -137,7 +140,19 @@ function logout() {
     window.location.href = `${getAppLoginUrl()}?isLoggedOut=true&redirectUrl=${redirectUrl}`
   })
 }
+const cameFromAdmin = ref(sessionStorage.getItem("cameFromAdmin") === "true");
 
+function goToTabs() {
+  const currentPath = router.currentRoute.value.fullPath;
+
+  if (currentPath.includes('/tabs/')) {
+    router.push('/draft');
+  } else {
+    cameFromAdmin.value = true; 
+    sessionStorage.setItem("cameFromAdmin", "true");
+    router.replace('/tabs/'); 
+  }
+}
 function goToLaunchpad() {
   window.location.href = `${getAppLoginUrl()}`
 }

--- a/src/views/Settings.vue
+++ b/src/views/Settings.vue
@@ -29,9 +29,10 @@
             {{ translate("Go to Launchpad") }}
             <ion-icon slot="end" :icon="openOutline" />
           </ion-button>
-         <ion-button v-if="(router.currentRoute.value.fullPath.includes('/tabs/') && cameFromAdmin) ||!router.currentRoute.value.fullPath.includes('/tabs/')" color="danger" @click="goToTabs()">
-            {{ router.currentRoute.value.fullPath.includes('/tabs/') ? translate("go to admin") : translate("go to store") }}
-         </ion-button>
+          <ion-button v-if="hasPermission('APP_DRAFT_VIEW')" fill="outline" @click="goToTabs()">
+           {{ router.currentRoute.value.fullPath.includes('/tabs/') ? translate('go to admin') : translate('go to store') }}
+          </ion-button>
+
         </ion-card>
       </div>
       <div class="section-header">
@@ -140,17 +141,14 @@ function logout() {
     window.location.href = `${getAppLoginUrl()}?isLoggedOut=true&redirectUrl=${redirectUrl}`
   })
 }
-const cameFromAdmin = ref(sessionStorage.getItem("cameFromAdmin") === "true");
 
 function goToTabs() {
   const currentPath = router.currentRoute.value.fullPath;
 
   if (currentPath.includes('/tabs/')) {
-    router.push('/draft');
+    router.push('/draft'); 
   } else {
-    cameFromAdmin.value = true; 
-    sessionStorage.setItem("cameFromAdmin", "true");
-    router.replace('/tabs/'); 
+    router.replace('/tabs/');
   }
 }
 function goToLaunchpad() {


### PR DESCRIPTION
### Related Issues
https://github.com/hotwax/inventory-count/issues/754

Added a button in the Settings screen to access the store view. The "Go to Admin" button is now shown only when the user navigates from the admin view; otherwise, it remains hidden.

<img width="1920" height="1080" alt="Screenshot from 2025-08-11 15-18-35" src="https://github.com/user-attachments/assets/a42a0f1b-bea3-49b6-a872-5faf009d654f" />
