### PR TITLE
FIX:Barcode Identifiers Are Not Listed On Store Permissions Page 

### DIFF
--- a/src/store/modules/user/actions.ts
+++ b/src/store/modules/user/actions.ts
@@ -194,7 +194,6 @@ const actions: ActionTree<UserState, RootState> = {
       "productStoreId": productStoreId ? productStoreId : getProductStoreId(),
       "settingTypeEnumId": "INV_CNT_VIEW_QOH,INV_FORCE_SCAN,INV_COUNT_FIRST_SCAN,BARCODE_IDEN_PREF",
       "settingTypeEnumId_op": "in",
-      "pageSize": 10
     }
 
     try {


### PR DESCRIPTION
resove the issue of not showing all the barcode identifiers  
issue 1:https://github.com/hotwax/inventory-count/issues/735
issue 2:https://github.com/hotwax/inventory-count/issues/739
