### PR TITLE
Fixed: when unmatched items are not present, ensure the counted value is saved on segment change (#752)

### DIFF
--- a/src/views/CountDetail.vue
+++ b/src/views/CountDetail.vue
@@ -490,7 +490,7 @@ async function scanProduct() {
 async function updateFilteredItems() {
   // If scrolling animation is disabled and there are items with inputCount,
   // save the current product count before switching segments
-  if(!isScrollingAnimationEnabled.value && itemsList.value?.length && inputCount.value) {
+  if(!isScrollingAnimationEnabled.value && inputCount.value) {
     await saveCount(product.value)
   }
   if (itemsList.value.length > 0) {

--- a/src/views/HardCountDetail.vue
+++ b/src/views/HardCountDetail.vue
@@ -375,7 +375,7 @@ async function handleSegmentChange() {
   isScanTriggered.value = false;
   // If scrolling animation is disabled and there are items with inputCount,
   // save the current product count before switching segments
-  if(!isScrollingAnimationEnabled.value && itemsList.value?.length && inputCount.value) {
+  if(!isScrollingAnimationEnabled.value && inputCount.value) {
     await saveCount(currentProduct.value)
   }
   if(itemsList.value.length) {


### PR DESCRIPTION

### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#752 

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
- Fixed saving the counted value on segment change when no unmatched items exist

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I have read and followed [contribution rules](https://github.com/hotwax/inventory-count#contribution-guideline)
