### PR TITLE
Fixed: scanned item quantity not saved when the user scans multiple products while scanning is disabled (#747)

### DIFF
--- a/src/views/CountDetail.vue
+++ b/src/views/CountDetail.vue
@@ -13,7 +13,7 @@
             <ion-item :disabled="isLoadingItems" lines="full">
               <ion-input :label="translate('Scan items')" :placeholder="translate('Scan or search products')" ref="barcodeInput" @ionFocus="selectSearchBarText($event)" v-model="queryString" @keyup.enter="scanProduct()"/>
             </ion-item>
-            <ion-segment :disabled="isLoadingItems" v-model="selectedSegment" @ionChange="updateFilteredItems()">
+            <ion-segment :disabled="isLoadingItems" v-model="selectedSegment" @ionChange="segmentChange()">
               <template v-if="cycleCount?.statusId === 'INV_COUNT_ASSIGNED'">
                 <ion-segment-button value="all">
                   <ion-label>{{ translate("ALL") }}</ion-label>
@@ -391,7 +391,7 @@ function updateAnimatingProduct(item) {
 
 function handleProductClick(item) {
   if(item) {
-    if(inputCount.value) saveCount(product.value, true)
+    if(inputCount.value && item.importItemSeqId) saveCount(product.value, true)
     store.dispatch("product/currentProduct", item);
     previousItem = item   
   }
@@ -487,12 +487,16 @@ async function scanProduct() {
   queryString.value = ""
 }
 
-async function updateFilteredItems() {
+async function segmentChange() {
   // If scrolling animation is disabled and there are items with inputCount,
   // save the current product count before switching segments
   if(!isScrollingAnimationEnabled.value && itemsList.value?.length && inputCount.value) {
     await saveCount(product.value)
   }
+  await updateFilteredItems();
+}
+
+async function updateFilteredItems() {
   if (itemsList.value.length > 0) {
     // As we want to get the index of the product, if we directly store the product in the updatedProduct variable it does not return the index
     // as both the object becomes different because of the reference, so if we have a product, then first finding it in the filtered list to have a common reference and then getting the index

--- a/src/views/HardCountDetail.vue
+++ b/src/views/HardCountDetail.vue
@@ -345,7 +345,7 @@ async function handleBeforeUnload() {
 
 function handleProductClick(item: any) {
   if(item) {
-    if(inputCount.value) saveCount(currentProduct.value, true)
+    if(inputCount.value && item.importItemSeqId) saveCount(currentProduct.value, true)
     store.dispatch("product/currentProduct", item);
     previousItem = item
   }
@@ -610,7 +610,7 @@ async function updateCurrentItemInList(newItem: any, scannedValue: string) {
     newCount = Number(inputCount.value || 0) + Number(updatedItem.scannedCount || 0)
   }
 
-  if(newCount) {
+  if(newCount && updatedItem?.importItemSeqId && updatedItem.productId) {
     try {
       const resp = await CountService.updateCount({
         inventoryCountImportId: cycleCount.value.inventoryCountImportId,


### PR DESCRIPTION

### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#747 

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
- On segment change fixed the alert box open error in directed count.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I have read and followed [contribution rules](https://github.com/hotwax/inventory-count#contribution-guideline)
