### PR TITLE
solved Label Truncated Issue

### DIFF
--- a/src/views/CountDetail.vue
+++ b/src/views/CountDetail.vue
@@ -852,7 +852,6 @@ ion-list {
     column-gap: var(--spacer-2xl);
   }
  .find >.filters {
-    width:433px;
     display: unset;
   }
 }


### PR DESCRIPTION
## Description
<br>

Truncated Label "NOT COUNTED " is now visible 

Before : 
<img width="802" height="388" alt="image" src="https://github.com/user-attachments/assets/42acc9c5-de96-4f9d-ae73-6d3c24d64623" />
<br>

After: 
<img width="475" height="259" alt="Screenshot from 2025-10-11 13-35-07" src="https://github.com/user-attachments/assets/3943f626-3a74-416d-b813-90772f9211f8" />

Increased the width of .filters from 375px to 433px


