### PR TITLE
Improved: Handled fetching InventoryCountImportItem records from the server

### DIFF
--- a/src/views/SessionCountDetail.vue
+++ b/src/views/SessionCountDetail.vue
@@ -514,6 +514,7 @@ const productIdentificationStore = useProductIdentificationStore();
 const {
   recordScan,
   getScanEvents,
+  getInventoryRecordsFromIndexedDB,
   loadInventoryItemsFromBackend,
   getUnmatchedItems,
   getCountedItems,
@@ -706,7 +707,12 @@ async function startSession() {
     }
 
     // Load InventoryCountImportItem records into IndexedDB
-    await loadInventoryItemsFromBackend(props.inventoryCountImportId);
+    const localRecords = await getInventoryRecordsFromIndexedDB(props.inventoryCountImportId);
+
+    if (!localRecords?.length) {
+      console.log("[Session] No local records found, fetching from backend...");
+      await loadInventoryItemsFromBackend(props.inventoryCountImportId);
+    }
 
     // Prefetch product details for all related productIds
     const productIds = await getAllProductIdsFromIndexedDB(props.inventoryCountImportId);


### PR DESCRIPTION
### Related Issues
#

### Short Description and Why It's Useful
- Made fetching logic optional if the records already exist in the local storage.

### Screenshots of Visual Changes before/after (If There Are Any)


### Contribution and Currently Important Rules Acceptance

- [x] I have read and followed [contribution rules](https://github.com/hotwax/inventory-count#contribution-guideline)
