### PR TITLE
Remove the query string from the Match Modal empty state

### DIFF
--- a/src/views/SessionCountDetail.vue
+++ b/src/views/SessionCountDetail.vue
@@ -1025,13 +1025,14 @@ function openMatchModal(item: any) {
 }
 
 function closeMatchModal() {
+  selectedProductId.value = '';
   isMatchModalOpen.value = false;
   products.value = [];
   queryString.value = "";
 }
 
 async function handleSearch() {
-  if (selectedProductId.value) selectedProductId.value = '';
+  selectedProductId.value = '';
   if (!queryString.value.trim()) {
     isSearching.value = false;
     return;


### PR DESCRIPTION
Related Issue - #967 

- Hide the Searched String from the Empty State.
- On Enter on searchbar clear any previous selected product.