### PR TITLE
Prevent Create Session Modal Dismissal

### DIFF
--- a/src/views/Count.vue
+++ b/src/views/Count.vue
@@ -121,7 +121,7 @@
           </ion-list>
         </ion-card>
       </template>
-      <ion-modal :is-open="isAddSessionModalOpen" @did-dismiss="isAddSessionModalOpen = false" :presenting-element="pageRef?.$el" :keep-contents-mounted="true">
+      <ion-modal :is-open="isAddSessionModalOpen" @did-dismiss="isAddSessionModalOpen = false" :presenting-element="pageRef?.$el" :keep-contents-mounted="true" :backdrop-dismiss="false">
           <ion-header>
             <ion-toolbar>
               <ion-buttons slot="start">


### PR DESCRIPTION
## Goal Description
The "Create Session" modal currently closes when the user taps the backdrop. The goal is to prevent this behavior so the modal remains open until explicitly closed by the user (e.g., via the close button or after successful submission).

## Proposed Changes
### `src/views/Count.vue`
- Add `:backdrop-dismiss="false"` to the `ion-modal` component used for creating a new session.

## Verification Plan
### Manual Verification
- Open the "Create Session" modal.
- Tap on the backdrop (outside the modal).
- Verify that the modal does **not** close.
- Verify that the close button still works.
- Verify that creating a session still works and closes the modal.