### PR TITLE
Added: prdocutId whencapturing ScanEvent of pre-counted item

### DIFF
--- a/src/composables/useInventoryCountImport.ts
+++ b/src/composables/useInventoryCountImport.ts
@@ -6,6 +6,7 @@ import { db, ScanEvent } from '@/services/commonDatabase'
 
 interface RecordScanParams {
   inventoryCountImportId: string;
+  productId?: string;
   productIdentifier: string;
   quantity: number;
   locationSeqId?: string | null;
@@ -23,6 +24,7 @@ function currentMillis(): number {
     const event: ScanEvent = {
       inventoryCountImportId: params.inventoryCountImportId,
       locationSeqId: params.locationSeqId || null,
+      productId: params.productId || null,
       scannedValue: params.productIdentifier,
       quantity: params.quantity,
       createdAt: currentMillis(),

--- a/src/services/commonDatabase.ts
+++ b/src/services/commonDatabase.ts
@@ -31,7 +31,7 @@ export interface InventoryCountImportItem {
 export interface ScanEvent {
   id?: number
   scannedValue?: string
-  productId?: string
+  productId?: string | null
   inventoryCountImportId: string
   locationSeqId?: string | null
   quantity: number

--- a/src/views/PreCountedItems.vue
+++ b/src/views/PreCountedItems.vue
@@ -258,6 +258,7 @@ async function setProductQoh(product: any) {
 async function addPreCountedItemInScanEvents(product: any) {
   await recordScan({
     inventoryCountImportId: props.inventoryCountImportId,
+    productId: product.productId,
     productIdentifier: await useProductStore().getProductIdentificationValue(product.productId, useProductStore().getProductIdentificationPref.primaryId),
     quantity: product.countedQuantity,
   })

--- a/src/workers/backgroundAggregation.ts
+++ b/src/workers/backgroundAggregation.ts
@@ -237,7 +237,7 @@ async function aggregate(inventoryCountImportId: string, context: any) {
 
     const grouped: Record<string, number> = {}
     for (const scan of scans) {
-      const key = scan.scannedValue?.trim()
+      const key = scan.productId || scan.scannedValue?.trim()
       if (!key) continue
       grouped[key] = (grouped[key] || 0) + (scan.quantity || 1)
     }


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->
#1006 

### Short Description and Why It's Useful
- Since pre-counted page supports keyword search, the scanEvent will capture the productId too, as the barcode identifier might be missing for the product, which will move it to the Unmatched section, which should not be the case. 

### Screenshots of Visual Changes before/after (If There Are Any)


### Contribution and Currently Important Rules Acceptance

- [x] I have read and followed [contribution rules](https://github.com/hotwax/inventory-count#contribution-guideline)
