### PR TITLE
feat: update export history sorting and date format

### DIFF
--- a/src/views/ExportHistory.vue
+++ b/src/views/ExportHistory.vue
@@ -51,7 +51,7 @@ import { useInventoryCountRun } from '@/composables/useInventoryCountRun';
 import { hasError } from '@/stores/authStore';
 import { showToast } from '@/services/uiUtils';
 import logger from '@/logger';
-import { getDateWithOrdinalSuffix } from '@/services/utils';
+import { getDateTimeWithOrdinalSuffix } from '@/services/utils';
 import { saveAs } from 'file-saver';
 
 const systemMessages = ref<any[]>([]);
@@ -62,7 +62,7 @@ onIonViewDidEnter(async () => {
 
 async function fetchExportHistory() {
   try {
-    const resp = await useInventoryCountRun().getExportedCycleCountsSystemMessages({systemMessageTypeId: 'ExportInventoryCounts', orderByField: 'initDate'});
+    const resp = await useInventoryCountRun().getExportedCycleCountsSystemMessages({systemMessageTypeId: 'ExportInventoryCounts', orderByField: 'initDate DESC'});
 
     if (!hasError(resp)) {
       const data = resp?.data || {};
@@ -79,7 +79,7 @@ async function fetchExportHistory() {
 }
 
 function formatDate(value: any) {
-  return value ? getDateWithOrdinalSuffix(value) : '-';
+  return value ? getDateTimeWithOrdinalSuffix(value) : '-';
 }
 
 function getUserLogin(message: any) {


### PR DESCRIPTION
# Export History Sorting and Date Format Update

## Changes
- **Sorting**: Updated `fetchExportHistory` in `ExportHistory.vue` to request data sorted by `initDate` in descending order (`initDate DESC`).
- **Date Format**: Updated `formatDate` in `ExportHistory.vue` to use `getDateTimeWithOrdinalSuffix` instead of `getDateWithOrdinalSuffix`, ensuring both date and time are displayed.
- **Imports**: Updated imports in `ExportHistory.vue` to include `getDateTimeWithOrdinalSuffix`.

## Verification Results

### Manual Verification
- Verified that the API call in `fetchExportHistory` now includes `orderByField: 'initDate DESC'`.
- Verified that `formatDate` now calls `getDateTimeWithOrdinalSuffix`.
- Verified that `getDateTimeWithOrdinalSuffix` is correctly imported.

## Files Modified
- `src/views/ExportHistory.vue`