### PR TITLE
Remove old cycle count status transition buttons

### DIFF
--- a/src/views/Count.vue
+++ b/src/views/Count.vue
@@ -111,15 +111,7 @@
                 </ion-item>
               </ion-item-group>
 
-            <ion-item lines="none">
-              <ion-button v-if="count.currentStatusId === 'CYCLE_CNT_IN_PRGS'" expand="block" size="default" fill="clear" slot="end" @click.stop="markAsCompleted(count.workEffortId)" :disabled="!count.sessions?.length || count.sessions.some(session => session.statusId === 'SESSION_CREATED' || session.statusId === 'SESSION_ASSIGNED')">
-                {{ translate("Ready for review") }}
-              </ion-button>
-              <!-- <ion-button
-                v-if="count.currentStatusId === 'CYCLE_CNT_CREATED'" expand="block" size="default" fill="clear" slot="end" @click="markInProgress(count.workEffortId)" :disabled="isPlannedForFuture(count)">
-                {{ translate("Move to In Progress") }}
-              </ion-button> -->
-            </ion-item>
+
           </ion-list>
         </ion-card>
       </template>


### PR DESCRIPTION
Removed old ion-item and buttons from the bottom of the cycle count card in Count.vue as they have been replaced by new buttons.