### PR TITLE
Fixed: Set the user's timezone as the default timezone for the app at login and whenever the timezone is changed.

### DIFF
--- a/src/stores/authStore.ts
+++ b/src/stores/authStore.ts
@@ -7,6 +7,7 @@ import { showToast } from '@/services/uiUtils';
 import { translate } from '@/i18n';
 import { useInventoryCountRun } from '@/composables/useInventoryCountRun';
 import { useProductStore } from './productStore';
+import { Settings } from 'luxon';
 
 export interface LoginPayload {
   token: any;
@@ -87,6 +88,7 @@ export const useAuthStore = defineStore('authStore', {
 
         const permissionId = process.env.VUE_APP_PERMISSION_ID;
         const current = await useUserProfile().getProfile(this.token.value, this.getBaseUrl);
+        Settings.defaultZone = current.timeZone;
 
         const serverPermissionsFromRules = getServerPermissionsFromRules();
         if (permissionId) serverPermissionsFromRules.push(permissionId);

--- a/src/stores/userProfileStore.ts
+++ b/src/stores/userProfileStore.ts
@@ -6,7 +6,7 @@ import logger from '@/logger'
 import i18n, { translate } from '@/i18n'
 import { prepareAppPermissions } from '@/authorization';
 import { getAvailableTimeZones, setUserTimeZone } from '@/adapter';
-import { DateTime } from 'luxon';
+import { DateTime, Settings } from 'luxon';
 
 export const useUserProfile = defineStore('userProfile', {
   state: () => ({
@@ -77,6 +77,7 @@ export const useUserProfile = defineStore('userProfile', {
         if (resp?.status === 200) {
           this.current.timeZone = tzId;
           this.currentTimeZoneId = tzId
+          Settings.defaultZone = tzId;
         } else {
           throw resp;
         }


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#

### Short Description and Why It's Useful
Fixed: Set the user's timezone as the default timezone for the app at login and whenever the timezone is changed.


### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [ ] I have read and followed [contribution rules](https://github.com/hotwax/inventory-count#contribution-guideline)
