### PR TITLE
Inventory count 3.0 matching undirected item

### DIFF
--- a/src/views/SessionCountDetail.vue
+++ b/src/views/SessionCountDetail.vue
@@ -1129,7 +1129,7 @@ async function saveMatchProduct() {
     token: useAuthStore().token.value,
     omsUrl: useAuthStore().getOmsRedirectionUrl,
     userLoginId: useUserProfile().getUserProfile?.username,
-    isRequested: existingUndirected ? existingUndirected.isRequested : 'N',
+    isRequested: existingUndirected ? existingUndirected.isRequested : props.inventoryCountTypeId === 'DIRECTED_COUNT' ? 'N' : '',
   };
 
   const plainItem = JSON.parse(JSON.stringify(toRaw(matchedItem.value)));


### PR DESCRIPTION
Related Issue: https://github.com/hotwax/inventory-count/issues/1063

If found then set its isRequested
If not found then set as N, since the item is found in Directed Count Session means it is undirected.