### PR TITLE
Add missing translation strings and sort locale entries

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -210,7 +210,7 @@
   "Please select at least one field to generate CSV": "Please select at least one field to generate CSV",
   "Please skip all undirected items before submitting for review": "Please skip all undirected items before submitting for review",
   "Please upload a valid csv to continue": "Please upload a valid csv to continue",
-  "Preparing file to downlaod...": "Preparing file to downlaod...",
+  "Preparing file to download...": "Preparing file to download...",
   "Preview count": "Preview count",
   "Primary": "Primary",
   "Product SKU": "Product SKU",


### PR DESCRIPTION
## Summary
- add the missing locale strings used throughout the application to prevent untranslated labels
- alphabetize the English locale file for easier upkeep

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_692e827122888321b43618ae1ad1d7c4)