### PR TITLE
Update undirected guidance on progress review page

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -248,6 +248,8 @@
   "UndirectedWithCount": "Undirected ({undirectedItemsLength})",
   "Undirected items are products you counted but were not instructed to count in this session. Don't worry about them during counting - you'll have a chance to discard them when reviewing and completing this count.": "Undirected items are products you counted but were not instructed to count in this session. Don't worry about them during counting - you'll have a chance to discard them when reviewing and completing this count.",
   "If these items were not intended to be counted in this session, you can discard them on the review and complete page.": "If these items were not intended to be counted in this session, you can discard them on the review and complete page.",
+  "Undirected items are products you counted even though they weren't requested in this directed count. Review this section to decide whether to keep them before completing the count.": "Undirected items are products you counted even though they weren't requested in this directed count. Review this section to decide whether to keep them before completing the count.",
+  "If these items were not intended to be counted in this session, discard them here before sending the count for head office approval.": "If these items were not intended to be counted in this session, discard them here before sending the count for head office approval.",
   "Units": "Units",
   "Units counted": "Units counted",
   "Unmatched": "Unmatched ({unmatchedItemsLength})",

--- a/src/views/CountProgressReview.vue
+++ b/src/views/CountProgressReview.vue
@@ -147,12 +147,12 @@
             </div>
             <div v-else-if="!isLoadingUndirected && undirectedItems.length === 0" class="empty-state">
               <h2>{{ translate("No undirected items") }}</h2>
-              <p>{{ translate("Undirected items are products you counted but were not instructed to count in this session. Don't worry about them during counting - you'll have a chance to discard them when reviewing and completing this count.") }}</p>
+              <p>{{ translate("Undirected items are products you counted even though they weren't requested in this directed count. Review this section to decide whether to keep them before completing the count.") }}</p>
             </div>
             <template v-else>
               <ion-card class="info-card ion-margin">
                 <ion-card-content>
-                  <p class="ion-text-wrap">{{ translate("If these items were not intended to be counted in this session, you can discard them on the review and complete page.") }}</p>
+                  <p class="ion-text-wrap">{{ translate("If these items were not intended to be counted in this session, discard them here before sending the count for head office approval.") }}</p>
                 </ion-card-content>
               </ion-card>
               <ion-accordion-group>


### PR DESCRIPTION
## Summary
- add distinct copy on the count progress review page to explain undirected items and highlight discard action there
- keep existing undirected messaging for session count detail while adding new translations for review-specific guidance

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_692e94af44248321b6b29dff3805e0fd)