### PR TITLE
Improve scanner focus button lifecycle

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -297,6 +297,8 @@
   "sku": "sku",
   "started": "started",
   "start counting": "start counting",
+  "Scanner focused": "Scanner focused",
+  "Focus scanner": "Focus scanner",
   "store name": "store name",
   "submitted counts": "{submittedItemsCount} out of {totalItems} items complete",
   "systemic": "systemic",


### PR DESCRIPTION
## Summary
- update the session detail start scanning button to reflect session status and scanner focus state
- change the button action to mark created sessions as in progress when scanning starts
- add translations for the new focus-related button labels

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_692e9757d75083219d82ca46925dcbc5)