### PR TITLE
Localize submit session alert messaging

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -40,6 +40,8 @@
   "Closed Date": "Closed Date",
   "Created Date": "Created Date",
   "Complete": "Complete",
+  "Complete session": "Complete session",
+  "You’re about to complete this session in the cycle count and won’t be able to edit it again. After all sessions are completed, submit the cycle count for approval from the review cycle count page.": "You’re about to complete this session in the cycle count and won’t be able to edit it again. After all sessions are completed, submit the cycle count for approval from the review cycle count page.",
   "Configure threshold": "Configure threshold",
   "Confirm": "Confirm",
   "Count": "Count",

--- a/src/views/SessionCountDetail.vue
+++ b/src/views/SessionCountDetail.vue
@@ -521,7 +521,7 @@
           <ion-img :src="largeImage" />
         </ion-content>
       </ion-modal>
-      <ion-alert :is-open="showSubmitAlert" header="Submit for review" message="Make sure you’ve reviewed the products and their counts before uploading them for review."
+      <ion-alert :is-open="showSubmitAlert" :header="translate('Complete session')" :message="translate('You’re about to complete this session in the cycle count and won’t be able to edit it again. After all sessions are completed, submit the cycle count for approval from the review cycle count page.')"
         :buttons="[
           { text: 'Cancel', role: 'cancel', handler: () => showSubmitAlert = false },
           { text: 'Submit', role: 'confirm', handler: confirmSubmit }


### PR DESCRIPTION
## Summary
- localize the submit session alert header and message using translation strings
- add English localization entries for the updated submit session alert copy

## Testing
- npm run lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_692eb4cecce8832186601d22042c94c4)