### PR TITLE
Store Product ID in Scan Event when capturing pre counted item

### DIFF
--- a/src/composables/useInventoryCountImport.ts
+++ b/src/composables/useInventoryCountImport.ts
@@ -7,6 +7,7 @@ import { useProductStore } from '@/stores/productStore';
 
 interface RecordScanParams {
   inventoryCountImportId: string;
+  productId?: string;
   productIdentifier: string;
   quantity: number;
   locationSeqId?: string | null;
@@ -23,6 +24,7 @@ function currentMillis(): number {
   async function recordScan(params: RecordScanParams): Promise<void> {
     const event: ScanEvent = {
       inventoryCountImportId: params.inventoryCountImportId,
+      productId: params.productId || null,
       locationSeqId: params.locationSeqId || null,
       scannedValue: params.productIdentifier,
       quantity: params.quantity,

--- a/src/services/commonDatabase.ts
+++ b/src/services/commonDatabase.ts
@@ -39,7 +39,7 @@ export interface InventoryCountImportItem {
 export interface ScanEvent {
   id?: number
   scannedValue?: string
-  productId?: string
+  productId?: string | null
   inventoryCountImportId: string
   locationSeqId?: string | null
   quantity: number

--- a/src/views/PreCountedItems.vue
+++ b/src/views/PreCountedItems.vue
@@ -385,6 +385,7 @@ async function setProductQoh(product: any) {
 async function addPreCountedItemInScanEvents(product: any) {
   await recordScan({
     inventoryCountImportId: props.inventoryCountImportId,
+    productId: product.productId,
     productIdentifier: await useProductStore().getProductIdentificationValue(product.productId, useProductStore().getProductIdentificationPref.primaryId),
     quantity: product.countedQuantity,
   })

--- a/src/workers/backgroundAggregation.ts
+++ b/src/workers/backgroundAggregation.ts
@@ -237,7 +237,7 @@ async function aggregate(inventoryCountImportId: string, context: any) {
 
     const grouped: Record<string, number> = {}
     for (const scan of scans) {
-      const key = scan.scannedValue?.trim()
+      const key = scan.productId || scan.scannedValue?.trim()
       if (!key) continue
       grouped[key] = (grouped[key] || 0) + (scan.quantity || 1)
     }


### PR DESCRIPTION
Related Issue: #1006 

The changes are referenced from this PR: https://github.com/hotwax/inventory-count/pull/1029/files

The Changes was some how lost in development, hence re-introducing them in this PR.