### PR TITLE
Use success color for applied pending reviews

### DIFF
--- a/src/views/PendingReviewDetail.vue
+++ b/src/views/PendingReviewDetail.vue
@@ -149,7 +149,7 @@
                       </div>
                       <ion-badge
                         v-else
-                        :color="item.decisionOutcomeEnumId === 'APPLIED' ? 'primary' : 'danger'"
+                        :color="item.decisionOutcomeEnumId === 'APPLIED' ? 'success' : 'danger'"
                         style="--color: white;"
                       >
                         {{ item.decisionOutcomeEnumId }}


### PR DESCRIPTION
## Summary
- change applied decision badges on pending review items to use the success color

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_692fd8021e288321ace0e06ad42fb49a)