### PR TITLE
Remove loader when adding pre-counted item

### DIFF
--- a/src/views/PreCountedItems.vue
+++ b/src/views/PreCountedItems.vue
@@ -355,7 +355,6 @@ async function getProducts(query: any) {
 }
 
 async function addProductInPreCountedItems(product: any) {
-  await loader.present('Loading...')
   try {
     searchedProductString.value = ''
     searchedProducts.value = []
@@ -373,8 +372,6 @@ async function addProductInPreCountedItems(product: any) {
   } catch (err) {
     console.error('Error adding product:', err)
   }
-
-  await loader.dismiss()
 
   // Focus the quantity input for the newly added product
   await focusQuantityInput(product.productId)


### PR DESCRIPTION
## Summary
- remove loading indicator when adding searched items to the pre-counted list
- keep quantity focus behavior unchanged while simplifying add flow

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_692fee6ee2188321b978fb7fc2a8c1cd)