### PR TITLE
Ensure pre-counted item removal targets a single entry

### DIFF
--- a/src/views/PreCountedItems.vue
+++ b/src/views/PreCountedItems.vue
@@ -229,6 +229,8 @@ function onManualInputChange(event: CustomEvent, product: any) {
 function setQuantityInputRef(sequenceId: string, el: any) {
   if (el) {
     quantityInputRefs.value[sequenceId] = el
+  } else {
+    delete quantityInputRefs.value[sequenceId]
   }
 }
 


### PR DESCRIPTION
## Summary
- assign unique sequence identifiers to each pre-counted item when added
- update UI bindings to rely on the sequence id for keys and quantity inputs
- remove items by sequence id so only the selected instance is deleted

## Testing
- npm run lint *(fails with existing warnings about unused variables in other files)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_692ff097968c8321b291c6df9bc61045)