### PR TITLE
Restore scanner focus button state logic

### DIFF
--- a/src/views/SessionCountDetail.vue
+++ b/src/views/SessionCountDetail.vue
@@ -701,12 +701,7 @@ const scannerButtonLabel = computed(() => {
   return translate('Focus scanner');
 });
 
-const scannerButtonDisabled = computed(() =>
-  sessionLocked.value
-  || inventoryCountImport.value?.statusId === 'SESSION_VOIDED'
-  || inventoryCountImport.value?.statusId === 'SESSION_SUBMITTED'
-  || (hasSessionStarted.value && isScannerFocused.value)
-);
+const scannerButtonDisabled = computed(() => !isSessionMutable.value || (hasSessionStarted.value && isScannerFocused.value));
   
 watchEffect(() => {
   const distinctProducts = new Set(countedItems.value.map(item => item.productId)).size


### PR DESCRIPTION
## Summary
- track scanner input focus via ionFocus/ionBlur to update scanner state
- use the dedicated scanner button disabled state to reflect session status and focus

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_692ff9c208188321bd1fa8a14ef7b7fb)