### PR TITLE
Update out-of-stock bulk flow loader text

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -127,6 +127,7 @@
   "Logout": "Logout",
   "Map all required fields": "Map all required fields",
   "Mapping name": "Mapping name",
+  "Marking items as out of stock...": "Marking items as out of stock...",
   "Match": "Match",
   "Match Product": "Match Product",
   "Match product": "Match product",

--- a/src/views/CountProgressReview.vue
+++ b/src/views/CountProgressReview.vue
@@ -902,7 +902,7 @@ async function createSessionForUncountedItems() {
     showToast(translate('You do not have permission to perform this action'));
     return;
   }
-  await loader.present("Marking items as out of stock...");
+  await loader.present(translate("Marking items as out of stock..."));
   try {
     const newSession = {
       countImportName: workEffort.value?.workEffortName,


### PR DESCRIPTION
## Summary
- update the progress review loader message when creating an uncounted session to clarify it is marking items out of stock

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6932ab3916ec83219c715fd8831e2ce7)