### PR TITLE
Enforce session immutability before start

### DIFF
--- a/src/views/SessionCountDetail.vue
+++ b/src/views/SessionCountDetail.vue
@@ -701,7 +701,11 @@ const scannerButtonLabel = computed(() => {
   return translate('Focus scanner');
 });
 
-const scannerButtonDisabled = computed(() => sessionLocked.value || (isSessionInProgress.value && isScannerFocused.value));
+const scannerButtonDisabled = computed(() =>
+  sessionLocked.value
+  || !['SESSION_CREATED', 'SESSION_ASSIGNED'].includes(inventoryCountImport.value?.statusId)
+  || (isSessionInProgress.value && isScannerFocused.value)
+);
   
 watchEffect(() => {
   const distinctProducts = new Set(countedItems.value.map(item => item.productId)).size


### PR DESCRIPTION
## Summary
- restrict session mutability to assigned status so inputs remain disabled until start
- keep the start counting button enabled for newly created sessions while respecting lock state

## Testing
- npm run lint (fails: npm not available)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6932ab055c9c8321af32d1c5f68ff737)