### PR TITLE
Show BarCode Identifier pref from the state on the scan input label

### DIFF
--- a/src/views/SessionCountDetail.vue
+++ b/src/views/SessionCountDetail.vue
@@ -84,7 +84,7 @@
             <ion-item lines="none">
               <ion-label>
                 <p class="overline">{{ countTypeLabel }}</p>
-                <h1>{{ inventoryCountImport?.countImportName || 'Untitled session' }} {{ inventoryCountImport.facilityAreaId }}</h1>
+                <h1>{{ inventoryCountImport?.countImportName || 'Untitled session' }} {{ inventoryCountImport?.facilityAreaId }}</h1>
                 <p>Created by {{ userLogin?.userFullName ? userLogin.userFullName : userLogin?.username }}</p>
               </ion-label>
             </ion-item>


### PR DESCRIPTION
Related Issue: #1139 
Added computed ref property on the Session detail Page for Barcode Indentifier pref.