### PR TITLE
Prevent editing session items after variance decision

### DIFF
--- a/src/views/PendingReviewDetail.vue
+++ b/src/views/PendingReviewDetail.vue
@@ -219,8 +219,8 @@
               <ion-list>
                 <ion-list-header>{{ selectedProductCountReview?.internalName }}</ion-list-header>
                 <ion-item size="small">{{ translate('Last Counted') }}: {{ getDateTimeWithOrdinalSuffix(selectedSession?.createdDate) }}</ion-item>
-                <ion-item button @click="showEditImportItemsModal" size="small">{{ translate('Edit Count') }}: {{ selectedSession?.counted }}</ion-item>
-                <ion-item button @click="removeProductFromSession()">
+                <ion-item v-if="!selectedProductCountReview?.decisionOutcomeEnumId" button @click="showEditImportItemsModal" size="small">{{ translate('Edit Count') }}: {{ selectedSession?.counted }}</ion-item>
+                <ion-item v-if="!selectedProductCountReview?.decisionOutcomeEnumId" button @click="removeProductFromSession()">
                   <ion-label>
                     {{ translate('Remove from count') }}
                   </ion-label>


### PR DESCRIPTION
## Summary
- hide edit and remove actions in the session popover once a variance decision has been applied or skipped
- add computed helper to keep the popover read-only while still displaying product name and last counted time

## Testing
- npm run lint *(fails: npm is not available in the environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6932de7098ec832182d1024ed9ca1a51)