### PR TITLE
Fix: Hide preview sections and refactor bulk action logic (#1188)

### DIFF
--- a/src/views/CountProgressReview.vue
+++ b/src/views/CountProgressReview.vue
@@ -164,7 +164,9 @@
                           {{ item.quantityOnHand || item.quantityOnHandTotal || '-' }}
                           {{ translate("QoH") }}
                         </ion-label>
-                        <ion-checkbox slot="start"
+                        <ion-checkbox
+                            v-if="isCountStarted || isCountStatusBeyondCreated"
+                            slot="start"
                             :checked="outOfStockSelections[item.productId]"
                             :disabled="isSubmitted"
                             @ionChange="(event: any) => handleOutOfStockCheck(event, item)"


### PR DESCRIPTION
This PR addresses issue #1188 by improving the View Count page.

**Changes:**
- Hides 'Products Counted', 'Undirected', and 'Counted' sections when the cycle count has not started.
- Shows 'Uncounted' section by default to ensure a valid initial state.
- Refactors the 'Mark as Out of Stock' bulk action to:
    - Only appear when the count is 'In Progress'.
    - Remain disabled until all sessions are strictly in 'Submitted' status.
    - Simplified logic by removing redundant checks.