### PR TITLE
Only Show Submit Button if the Session is in Assigned Status

### DIFF
--- a/src/views/SessionCountDetail.vue
+++ b/src/views/SessionCountDetail.vue
@@ -115,7 +115,7 @@
                   <ion-icon slot="start" :icon="exitOutline"></ion-icon>
                   {{ translate("Discard") }}
                 </ion-button>
-                <ion-button v-if="inventoryCountImport?.statusId === 'SESSION_ASSIGNED'" color="success" fill="outline" @click="showSubmitAlert = true" :disabled="sessionLocked">
+                <ion-button v-if="isSessionInProgress" color="success" fill="outline" @click="showSubmitAlert = true" :disabled="sessionLocked">
                   <ion-icon slot="start" :icon="checkmarkDoneOutline"></ion-icon>
                   {{ translate("Submit") }}
                 </ion-button>


### PR DESCRIPTION
### Related Issues
#1198 
#

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
Hide the Submit Session Button if the Session is not in Assigned Status

### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I have read and followed [contribution rules](https://github.com/hotwax/inventory-count#contribution-guideline)
