### PR TITLE
Disable Quantity Buttons and Input once items get saved in indexed db

### DIFF
--- a/src/views/PreCountedItems.vue
+++ b/src/views/PreCountedItems.vue
@@ -242,7 +242,6 @@ onMounted(async () => {
 
 function incrementProductQuantity(product: any) {
   product.countedQuantity++
-  product.saved = false
 }
 
 function decrementProductQuantity(product: any) {


### PR DESCRIPTION
Only look for undirected items if count is directed removed logic for marking items as saved if the items quantity gets zero, as it was applied if already saved product with some quantity are zeroed out

### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->
#1225 

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->


### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I have read and followed [contribution rules](https://github.com/hotwax/inventory-count#contribution-guideline)
