### PR TITLE
Added set timeout in focus scanner calls and implementation

### DIFF
--- a/src/views/SessionCountDetail.vue
+++ b/src/views/SessionCountDetail.vue
@@ -703,7 +703,7 @@ const hasSessionStarted = computed(() =>
 const scannerButtonColor = computed(() => {
   if (inventoryCountImport.value?.statusId === 'SESSION_CREATED') return 'success';
   if (hasSessionStarted.value && !isScannerFocused.value) return 'danger';
-  return 'medium';
+  return 'success';
 });
 
 const scannerButtonLabel = computed(() => {
@@ -968,11 +968,22 @@ async function loadInventoryItemsWithProgress() {
   }
 }
 
-function focusScanner() {
-  barcodeInput.value?.$el?.setFocus();
-  isScannerFocused.value = true;
+async function focusScanner() {
+  if (!isSessionMutable.value) return;
+
   filteredItems.value = [];
   searchKeyword.value = '';
+
+  setTimeout(() => {
+    const el = barcodeInput.value?.$el;
+
+    if (el && typeof el.setFocus === 'function') {
+      el.setFocus();
+      isScannerFocused.value = true;
+    } else {
+      console.warn('Scanner element not ready', el);
+    }
+  }, 0);
 }
 
 function handleScan() {
@@ -1006,8 +1017,9 @@ async function handleStartOrFocus() {
       return;
     }
   }
-
-  focusScanner();
+  setTimeout(() => {
+    focusScanner();
+  }, 0);
 }
 
 function handleScannerFocus() {


### PR DESCRIPTION
Show Primary Color when scan input is focused

### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#1280 

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
The focus is happening when the dom is still being updated so the focus fails, added timeout to delay the focus till after dom update.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I have read and followed [contribution rules](https://github.com/hotwax/inventory-count#contribution-guideline)
