### PR TITLE
Prepare Good Indentifications and Product Identitfications on login

### DIFF
--- a/src/stores/authStore.ts
+++ b/src/stores/authStore.ts
@@ -136,6 +136,7 @@ export const useAuthStore = defineStore('authStore', {
         // Fetch and set product identifier settings based on current product store
         await useProductStore().getProductIdentifierSettings();
         await useProductStore().getSettings(useProductStore().getCurrentProductStore?.productStoreId);
+        await useProductStore().prepareProductIdentifierOptions();
         await useInventoryCountRun().loadStatusDescription();
 
         await initialize();

--- a/src/stores/productStore.ts
+++ b/src/stores/productStore.ts
@@ -197,7 +197,7 @@ export const useProductStore = defineStore('productStore', {
           url: `inventory-cycle-count/productStores/${productStoreId}/settings`,
           method: 'GET',
           params: {
-            settingTypeEnumId: ['INV_FORCE_SCAN', 'INV_CNT_VIEW_QOH', 'BARCODE_IDEN_PREF'],
+            settingTypeEnumId: ['INV_FORCE_SCAN', 'BARCODE_IDEN_PREF'],
             settingTypeEnumId_op: 'in',
             pageSize: 5
           }

--- a/src/views/SessionCountDetail.vue
+++ b/src/views/SessionCountDetail.vue
@@ -651,7 +651,7 @@ let lockGracePeriod = 300
 const showQoh = computed(() => hasPermission(Actions.APP_INV_CNT_VIEW_QOH));
 const getGoodIdentificationOptions = computed(() => useProductStore().getGoodIdentificationOptions);
 const barcodeIdentifierPref = computed(() => useProductStore().getBarcodeIdentificationPref);
-const barcodeIdentifierDescription = getGoodIdentificationOptions.value?.find((opt: any) => opt.goodIdentificationTypeId === barcodeIdentifierPref.value)?.description;
+const barcodeIdentifierDescription = computed(() => getGoodIdentificationOptions.value?.find((opt: any) => opt.goodIdentificationTypeId === barcodeIdentifierPref.value)?.description);
 
 const pageRef = ref(null);
 


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#1293 

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
- Prepare the Product and Good Identitfication options when the user logins, the Bar Code Identification was missing when the user lands to the app's default page, if the Store Associate opens a session directly after landing on the Counts Loist Page the Bar Code Identifications was missing above the Scan Input. The Options are only loaded if the Settings page is opened.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I have read and followed [contribution rules](https://github.com/hotwax/inventory-count#contribution-guideline)
