### PR TITLE
Fix systemic QOH when marking uncounted items out of stock

### DIFF
--- a/src/views/CountProgressReview.vue
+++ b/src/views/CountProgressReview.vue
@@ -1212,6 +1212,7 @@ async function markSelectedItemsOutOfStock() {
         inventoryCountImportId,
         productId: item.productId,
         quantity: 0,
+        systemQuantityOnHand: item.quantityOnHandTotal || item.quantityOnHand || 0,
         uploadedByUserLogin: username,
         uuid: uuidv4(),
         createdDate: DateTime.now().toMillis()


### PR DESCRIPTION
## Summary
- populate `systemQuantityOnHand` when marking uncounted items as out of stock

## Testing
- not run

Closes #1347