### PR TITLE
[codex] migrate deprecated inventory endpoints

### DIFF
--- a/src/adapter/index.ts
+++ b/src/adapter/index.ts
@@ -89,7 +89,7 @@ async function fetchFacilitiesByGroup(facilityGroupId: string, baseURL?: string,
 
 async function fetchFacilitiesByParty(partyId: string, baseURL?: string, token?: string, payload?: any): Promise <Array<any> | Response> {
   let params: RequestPayload = {
-    url: `inventory-cycle-count/user/${partyId}/facilities`,
+    url: `admin/user/${partyId}/facilities`,
     method: "GET",
     params: {
       ...payload,

--- a/src/stores/productStore.ts
+++ b/src/stores/productStore.ts
@@ -66,18 +66,6 @@ export const useProductStore = defineStore('productStore', {
 
   actions: {
     /** ---------- Product Store Management ---------- */
-    async loadStoresByFacility(facilityId: string) {
-      try {
-        const resp = await api({
-          url: `inventory-cycle-count/facilities/${facilityId}/productStores`,
-          method: 'GET'
-        })
-        if (!hasError(resp)) this.productStores = resp?.data
-      } catch (err) {
-        logger.error('Failed to load product stores', err)
-      }
-    },
-
     setCurrent(productStore: any) {
       this.currentProductStore = productStore
     },
@@ -195,7 +183,7 @@ export const useProductStore = defineStore('productStore', {
     async getSettings(productStoreId: string) {
       try {
         const resp = await api({
-          url: `inventory-cycle-count/productStores/${productStoreId}/settings`,
+          url: `admin/productStores/${productStoreId}/settings`,
           method: 'GET',
           params: {
             settingTypeEnumId: ['INV_FORCE_SCAN', 'BARCODE_IDEN_PREF'],
@@ -232,7 +220,7 @@ export const useProductStore = defineStore('productStore', {
 
       try {
         const resp = await api({
-          url: `inventory-cycle-count/productStores/${productStoreId}/settings`,
+          url: `admin/productStores/${productStoreId}/settings`,
           method: 'POST',
           data: {
             productStoreId,
@@ -308,18 +296,6 @@ export const useProductStore = defineStore('productStore', {
     },
 
     /** Facility specific functions */
-    async loadUserFacilities(partyId: string) {
-      try {
-        const resp = await api({
-          url: `inventory-cycle-count/users/${partyId}/facilities`,
-          method: 'GET'
-        })
-        if (!hasError(resp)) this.facilities = resp?.data
-      } catch (err) {
-        logger.error('Failed to load facilities', err)
-      }
-    },
-
     async getDxpUserFacilities(partyId: string, facilityGroupId: string, isAdminUser: boolean, payload = {}) {
       const authStore = useAuthStore()
       try {


### PR DESCRIPTION
## Business summary
This removes Inventory Count's remaining dependency on deprecated `inventory-cycle-count` endpoints so the app keeps working after the backend cleanup in hotwax/hotwax-poorti#247.

Closes #1397.

## What changed
- migrated non-admin facility lookup from `inventory-cycle-count/user/${partyId}/facilities` to `admin/user/${partyId}/facilities`
- migrated force-scan and barcode settings read/write from `inventory-cycle-count/productStores/${productStoreId}/settings` to `admin/productStores/${productStoreId}/settings`
- removed stale unused helpers that still referenced deprecated facility/product-store routes

## Why
The backend PR removes deprecated resources for `user`, `productStores`, `facilities`, `enums`, and `login` from `service/inventorycount.rest.xml`. Inventory Count had already moved some surfaces to `admin/...` and `oms/...`, but login facility resolution and store settings were still on the deprecated contract.

## Validation
- verified no remaining deprecated `inventory-cycle-count/user`, `inventory-cycle-count/users`, `inventory-cycle-count/facilities`, or `inventory-cycle-count/productStores` references remain under `src/`
- `npm run lint` passes with pre-existing warnings in `src/views/Tabs.vue`
- `npm run build` still fails for unrelated existing Shopify App Bridge module resolution and TS typing errors in `src/services/utils.ts`
