### PR TITLE
Fixed: skip facility party api call for admin users

### DIFF
--- a/src/stores/productStore.ts
+++ b/src/stores/productStore.ts
@@ -175,7 +175,7 @@ export const useProductStore = defineStore('productStore', {
       let facilityIds: Array<string> = [];
       let filters: any = {};
       let resp = {} as any
-      if(partyId) {
+      if(partyId && !isAdminUser) {
         try {
           resp = await this.fetchFacilitiesByParty(partyId, baseURL, token)
           facilityIds = resp.map((facility: any) => facility.facilityId);


### PR DESCRIPTION
Changelog: Fixed

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
This PR introduces the use of unused isAdminUser parameter when fetching user facilities.


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I have read and followed [contribution rules](https://github.com/hotwax/inventory-count#contribution-guideline)
