### PR TITLE
Fix: Enable side menu navigation on mobile viewports (#1420)

### DIFF
--- a/src/views/Assigned.vue
+++ b/src/views/Assigned.vue
@@ -3,6 +3,9 @@
     <!-- <Filters menu-id="assigned-filter" content-id="filter"/> -->
     <ion-header>
       <ion-toolbar>
+        <ion-buttons slot="start">
+          <ion-menu-button data-testid="settings-menu-btn" />
+        </ion-buttons>
         <ion-title data-testid="assigned-page-title">{{ translate("Assigned")}}</ion-title>
         <ion-buttons slot="end">
           <ion-menu-button menu="assigned-filter" data-testid="assigned-filter-menu-btn">

--- a/src/views/BulkUpload.vue
+++ b/src/views/BulkUpload.vue
@@ -2,6 +2,9 @@
   <ion-page>
     <ion-header :translucent="true">
       <ion-toolbar>
+        <ion-buttons slot="start">
+          <ion-menu-button data-testid="settings-menu-btn" />
+        </ion-buttons>
         <ion-title data-testid="bulk-upload-page-title">{{ translate("Draft bulk") }}</ion-title>
       </ion-toolbar>
     </ion-header>
@@ -141,7 +144,7 @@
 </template>
 
 <script setup>
-import { IonButton, IonContent, IonHeader, IonIcon, IonItem, IonItemDivider, IonLabel, IonList, IonListHeader, IonNote,   IonPage, IonSelect, IonSelectOption, IonTitle, IonToolbar, onIonViewDidEnter, IonModal, IonPopover, IonButtons } from '@ionic/vue';
+import { IonButton, IonContent, IonHeader, IonIcon, IonItem, IonItemDivider, IonLabel, IonList, IonListHeader, IonNote,   IonPage, IonSelect, IonSelectOption, IonTitle, IonToolbar, onIonViewDidEnter, IonModal, IonPopover, IonButtons, IonMenuButton } from '@ionic/vue';
 import { cloudUploadOutline, ellipsisVerticalOutline, bookOutline, close, downloadOutline, openOutline } from "ionicons/icons";
 import { commonUtil, translate, logger } from '@common';
 import { onBeforeUnmount, ref } from "vue";

--- a/src/views/Closed.vue
+++ b/src/views/Closed.vue
@@ -2,6 +2,9 @@
   <ion-page>
     <ion-header>
       <ion-toolbar>
+        <ion-buttons slot="start">
+          <ion-menu-button data-testid="settings-menu-btn" />
+        </ion-buttons>
         <ion-title data-testid="closed-page-title">{{ translate("Closed")}}</ion-title>
         <ion-buttons slot="end">
           <ion-button @click="router.push('/export-history')" data-testid="closed-export-history-btn">

--- a/src/views/PendingReview.vue
+++ b/src/views/PendingReview.vue
@@ -3,6 +3,9 @@
     <!-- <Filters menu-id="pending-review-filter" content-id="filter"/> -->
     <ion-header>
       <ion-toolbar>
+        <ion-buttons slot="start">
+          <ion-menu-button data-testid="settings-menu-btn" />
+        </ion-buttons>
         <ion-title data-testid="pending-review-page-title">{{ translate("Pending review")}}</ion-title>
         <ion-buttons slot="end">
           <ion-menu-button menu="pending-review-filter" data-testid="pending-review-filter-menu-btn">

--- a/src/views/Settings.vue
+++ b/src/views/Settings.vue
@@ -2,7 +2,9 @@
   <ion-page>
     <ion-header :translucent="true">
       <ion-toolbar>
-        <ion-menu-button slot="start" data-testid="settings-menu-btn" />
+        <ion-buttons slot="start">
+          <ion-menu-button data-testid="settings-menu-btn" />
+        </ion-buttons>
         <ion-title data-testid="settings-page-title">{{ translate("Settings") }}</ion-title>
       </ion-toolbar>
     </ion-header>

--- a/src/views/StorePermissions.vue
+++ b/src/views/StorePermissions.vue
@@ -2,6 +2,9 @@
   <ion-page>
     <ion-header>
       <ion-toolbar>
+        <ion-buttons slot="start">
+          <ion-menu-button data-testid="settings-menu-btn" />
+        </ion-buttons>
         <ion-title data-testid="store-permissions-page-title">{{ translate("Store permissions") }}</ion-title>
       </ion-toolbar>
     </ion-header>
@@ -166,7 +169,7 @@
 </template>
 
 <script setup lang="ts">
-import { IonButtons, IonButton, IonCard, IonCardContent, IonCardHeader, IonCardTitle, IonCheckbox, IonContent, IonFab, IonFabButton, IonHeader, IonIcon, IonItem, IonItemDivider, IonLabel, IonList, IonListHeader, IonModal, IonNote, IonPage, IonPopover, IonSearchbar, IonTitle, IonToolbar, alertController, onIonViewWillEnter } from "@ionic/vue";
+import { IonButtons, IonMenuButton, IonButton, IonCard, IonCardContent, IonCardHeader, IonCardTitle, IonCheckbox, IonContent, IonFab, IonFabButton, IonHeader, IonIcon, IonItem, IonItemDivider, IonLabel, IonList, IonListHeader, IonModal, IonNote, IonPage, IonPopover, IonSearchbar, IonTitle, IonToolbar, alertController, onIonViewWillEnter } from "@ionic/vue";
 import { ref, computed } from "vue";
 import { DateTime } from "luxon";
 import { translate, logger } from "@common";


### PR DESCRIPTION
### Related Issue

Closes #1420

### Problem

On mobile viewports, the menu button was not displayed on several admin screens, preventing users from opening the side navigation and switching between pages.

### Proposed Changes

- Wrapped `IonMenuButton` inside `IonButtons` with `slot="start"` in the affected admin view headers.
- Added the required `IonMenuButton` imports where missing.
- Aligned the header implementation with the existing navigation pattern used across the application.

### How Has This Been Tested?

- [x] Verified the menu button is visible on mobile viewports.
- [x] Verified tapping the menu button opens the side navigation.
- [x] Verified users can navigate between admin screens in mobile view.
- [x] Verified no changes to desktop navigation behavior.