### PR TITLE
fix: use relative paths for web workers to fix prod build

### DIFF
--- a/src/composables/useDiagnostics.ts
+++ b/src/composables/useDiagnostics.ts
@@ -64,7 +64,7 @@ export function useDiagnostics() {
     const scanTableExists = !!db.scanEvents;
     localResults.push({ name: "Scan event parsing", status: scanTableExists ? "passed" : "failed", detail: scanTableExists ? "Scan events exists" : "Scan events missing" });
     try {
-      const inventorySyncWorker = WorkerFactory.createWorker<InventorySyncWorker>(new URL('@/workers/backgroundAggregation.ts', import.meta.url)).api
+      const inventorySyncWorker = WorkerFactory.createWorker<InventorySyncWorker>(new URL('../workers/backgroundAggregation.ts', import.meta.url)).api
       await inventorySyncWorker.aggregate("diagnostic-test", {});
       localResults.push({ name: "Session lock heartbeat", status: "passed", detail: "Heartbeat worker initialized" });
     } catch (err) {

--- a/src/views/SessionCountDetail.vue
+++ b/src/views/SessionCountDetail.vue
@@ -1121,7 +1121,7 @@ onIonViewDidEnter(async () => {
     );
 
     // Start the background aggregation worker and schedule periodic aggregation
-    const bgWorker = WorkerFactory.createWorker<InventorySyncWorker>(new URL('@/workers/backgroundAggregation.ts', import.meta.url))
+    const bgWorker = WorkerFactory.createWorker<InventorySyncWorker>(new URL('../workers/backgroundAggregation.ts', import.meta.url))
     aggregationWorker = bgWorker.worker
     aggregationWorkerApi = bgWorker.api
     aggregationWorker.onmessage = (event) => {
@@ -1493,7 +1493,7 @@ async function handleSessionLock() {
       // Schedule heartbeat worker for existing lock
       let worker: Worker | null = null;
       if (!lockWorker) {
-        const workerConfig = WorkerFactory.createWorker<LockHeartbeatWorker>(new URL('@/workers/lockHeartbeatWorker.ts', import.meta.url))
+        const workerConfig = WorkerFactory.createWorker<LockHeartbeatWorker>(new URL('../workers/lockHeartbeatWorker.ts', import.meta.url))
         worker = workerConfig.worker
         lockWorker = workerConfig.api;
       }
@@ -1552,7 +1552,7 @@ async function handleSessionLock() {
 
       let worker: Worker | null = null;
       if (!lockWorker) {
-        const workerConfig = WorkerFactory.createWorker<LockHeartbeatWorker>(new URL('@/workers/lockHeartbeatWorker.ts', import.meta.url))
+        const workerConfig = WorkerFactory.createWorker<LockHeartbeatWorker>(new URL('../workers/lockHeartbeatWorker.ts', import.meta.url))
         worker = workerConfig.worker
         lockWorker = workerConfig.api;
       }

--- a/src/views/Variance.vue
+++ b/src/views/Variance.vue
@@ -642,7 +642,7 @@ onIonViewDidEnter(async () => {
     from(useProductMaster().getUnmatchedInventoryAdjustments()).subscribe((items: any) => (unmatchedItems.value = items))
   )
 
-  const bgWorker = WorkerFactory.createWorker<InventorySyncWorker>(new URL('@/workers/backgroundAggregation.ts', import.meta.url))
+  const bgWorker = WorkerFactory.createWorker<InventorySyncWorker>(new URL('../workers/backgroundAggregation.ts', import.meta.url))
   aggregationWorker = bgWorker.worker
   aggregationWorkerApi = bgWorker.api
 


### PR DESCRIPTION
### Related Issues
#1415

#

### Short Description and Why It's Useful
Fix Production Build Breaking on Web Worker Imports Vite was failing to bundle the application for production because it couldn't properly resolve the Web Worker imports when using absolute path aliases (like @/workers/...). This caused the build to crash.

This PR fixes the issue by updating the Web Worker instantiations to use native ES module relative paths with import.meta.url (e.g., new Worker(new URL('../workers/...', import.meta.url), { type: 'module' })). This is the officially supported Vite pattern for web workers and ensures that Rollup can properly trace, compile, and bundle the worker files during a production build without throwing circular dependency or pathing errors.


