### PR TITLE
fix: route runSolrQuery to maargUrl instead of omsUrl to fix 404 error

### DIFF
--- a/src/composables/useProductMaster.ts
+++ b/src/composables/useProductMaster.ts
@@ -174,7 +174,7 @@ async function findProductByIdentification(idType: string, value: string, contex
     .first()
   if (ident) return ident.productId
 
-  if (!context?.token || !context?.omsUrl) return null
+  if (!context?.token || !context?.maargUrl) return null
   if (!idType) idType = context.barcodeIdentification
 
   const query = useProductMaster().buildProductQuery({
@@ -184,7 +184,7 @@ async function findProductByIdentification(idType: string, value: string, contex
   });
   try {
     const resp = await workerRemoteApi({
-      baseURL: context.omsUrl,
+      baseURL: context.maargUrl,
       headers: {
         'Authorization': `Bearer ${context.token}`,
         'Content-Type': 'application/json'


### PR DESCRIPTION
### Related Issues
#1415 

### Short Description and Why It's Useful
Fix 404 Not Found error during Solr product lookups.

When scanning or searching for products in a cycle count session on deployed instances, the admin/runSolrQuery endpoint was failing with a 404 Not Found error from the Moqui framework.

###Root Cause
 The frontend was inadvertently routing the Solr lookup request to the OMS server (context.omsUrl) instead of the Maarg server (context.maargUrl). Because the OMS server does not contain the admin.rest.xml endpoints, it threw a 404 Could not find subscreen error.

Screenshots of Visual Changes before/after
N/A - This is a purely backend routing fix.
