### PR TITLE
Fixed: login failure when redirecting from launchpad

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -35,7 +35,6 @@ import piniaPluginPersistedstate from 'pinia-plugin-persistedstate'
 import { useUserProfile } from './stores/userProfileStore';
 import { db, initialize } from '@/services/appInitializer'
 import { createDxpI18n, initialiseConfig } from '@common'
-import { loader } from '@/services/uiUtils'
 import localeMessages from '@/locales'
 
 const i18n = createDxpI18n(localeMessages)
@@ -104,8 +103,13 @@ app.config.globalProperties.$filters = {
 
 router.isReady().then(async () => {
   try {
+    // Checking for oms and token in router, as when coming from launchpad with token and oms in url
+    // db intialize is called, but at the same time we are clearing the state and cookies to honor the data
+    // present in url, thus isAuthenticated checks fails in remoteApi for the device/id endpoint causing
+    // the login failure.
+    const routerQuery = router.currentRoute.value.query
     // Ensures the database is opened and schema initialized
-    if (!db) {
+    if (!db && !routerQuery.oms && !routerQuery.token) {
       await initialize();
     }
   } catch (error) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -107,6 +107,7 @@ router.isReady().then(async () => {
     // db intialize is called, but at the same time we are clearing the state and cookies to honor the data
     // present in url, thus isAuthenticated checks fails in remoteApi for the device/id endpoint causing
     // the login failure.
+    // TODO: The checks needs to be removed once we move launchpad to accxui cookies pattern
     const routerQuery = router.currentRoute.value.query
     // Ensures the database is opened and schema initialized
     if (!db && !routerQuery.oms && !routerQuery.token) {


### PR DESCRIPTION
Added check for router query params to check for oms and token values and if present not initialise db

### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
Steps to verify:
- Login into the app
- Click Go to launchpad from app
- From launchpad, move to inventory count dev app again

Before this fix the app fails to login, as the token and oms are present in url and in that case we clear the cookies and auth state, but at the same time the initialise call for fetching deviceId is triggered causing the isAuthenticated check to fail and thus app fails to login.

After this fix, in case when we have token and oms in url, we are simply bypassing calling the initialise method and instead the db initialise the handled in postLogin flow.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I have read and followed [contribution rules](https://github.com/hotwax/inventory-count#contribution-guideline)
