### PR TITLE
Fix: Pass search keyword to Pending Review API (#1445)

### DIFF
--- a/src/views/PendingReview.vue
+++ b/src/views/PendingReview.vue
@@ -174,8 +174,8 @@ async function getPendingCycleCounts() {
       pageIndex: pageIndex.value,
       statusId: "CYCLE_CNT_CMPLTD"
     } as any;
-    if (filters.value?.countQueryString) {
-      params.keyword = filters.value.countQueryString
+    if (searchQuery.value?.trim()) {
+      params.keyword = searchQuery.value.trim();
     }
     if (filters.value.countType) params.countType = filters.value.countType;
     if (filters.value.facilityIds?.length) {


### PR DESCRIPTION
### Related Issue

Closes #1445

### Summary

Fixes the Pending Review search by passing the entered search term as the `keyword` parameter in the API request, allowing searches by both Work Effort ID and Work Effort Name.

### Changes

- Updated `getPendingCycleCounts()` in `PendingReview.vue` to pass `searchQuery.value.trim()` as the `keyword` parameter.
- Removed the use of the unmapped `countQueryString` filter for search requests.

### Testing

1. Open the **Pending Review** page.
2. Search using a **Work Effort ID**.
3. Search using a **Work Effort Name**.
4. Verify the API request includes `keyword=<search_term>` and returns filtered results.